### PR TITLE
refactor(identityurl): build IdentityUrl from BaseURL

### DIFF
--- a/src/main/kotlin/com/expediagroup/sdk/core/client/Client.kt
+++ b/src/main/kotlin/com/expediagroup/sdk/core/client/Client.kt
@@ -45,7 +45,7 @@ class Client private constructor(
     init {
         httpClient = HttpClient(httpClientEngine) {
             val authenticationConfigs =
-                AuthenticationConfigs.from(this, configuration.clientConfiguration, environmentConfigs.identityUrl)
+                AuthenticationConfigs.from(this, configuration.clientConfiguration, environmentConfigs.baseUrl)
 
             plugins {
                 use(LoggingPlugin).with(LoggingConfigs.from(this))

--- a/src/main/kotlin/com/expediagroup/sdk/core/config/ClientCredentials.kt
+++ b/src/main/kotlin/com/expediagroup/sdk/core/config/ClientCredentials.kt
@@ -16,6 +16,6 @@
 package com.expediagroup.sdk.core.config
 
 data class ClientCredentials(
-    val clientId: String,
+    val clientKey: String,
     val clientSecret: String
 ) : AuthenticationConfiguration

--- a/src/main/kotlin/com/expediagroup/sdk/core/config/EnvironmentConfigurationProvider.kt
+++ b/src/main/kotlin/com/expediagroup/sdk/core/config/EnvironmentConfigurationProvider.kt
@@ -18,28 +18,29 @@ package com.expediagroup.sdk.core.config
 import com.expediagroup.sdk.core.config.provider.FileConfigurationProvider
 import com.expediagroup.sdk.core.constants.ClientConstants.BASE_URL
 import com.expediagroup.sdk.core.constants.ClientConstants.CLIENT_CONFIGS_FILE_PATH
-import com.expediagroup.sdk.core.constants.ClientConstants.CLIENT_ID
+import com.expediagroup.sdk.core.constants.ClientConstants.CLIENT_KEY
 import com.expediagroup.sdk.core.constants.ClientConstants.CLIENT_SECRET
 import com.expediagroup.sdk.core.constants.ClientConstants.CREDENTIALS_FILE_PATH
-import com.expediagroup.sdk.core.constants.ClientConstants.IDENTITY_URL
+import com.expediagroup.sdk.core.constants.ClientConstants.EMPTY_STRING
+import com.expediagroup.sdk.core.plugin.authentication.IdentityUrl
 
 object EnvironmentConfigurationProvider {
-
-    val configuration = prepareConfiguration()
-    val clientEnvironmentConfigs = prepareClientEnvironmentConfigs()
+    val configuration: Configuration = prepareConfiguration()
+    val clientEnvironmentConfigs: EnvironmentConfigs = prepareClientEnvironmentConfigs()
 
     private fun prepareConfiguration(): Configuration {
         val configurationData = FileConfigurationProvider()[CREDENTIALS_FILE_PATH]
-        val clientId = configurationData.data()[CLIENT_ID] ?: ""
-        val clientSecret = configurationData.data()[CLIENT_SECRET] ?: ""
-        return Configuration(ClientConfiguration(ClientCredentials(clientId, clientSecret)))
+        val clientKey = configurationData.data()[CLIENT_KEY] ?: EMPTY_STRING
+        val clientSecret = configurationData.data()[CLIENT_SECRET] ?: EMPTY_STRING
+
+        return Configuration(ClientConfiguration(ClientCredentials(clientKey, clientSecret)))
     }
 
     private fun prepareClientEnvironmentConfigs(): EnvironmentConfigs {
         val clientEnvironmentConfigsData = FileConfigurationProvider()[CLIENT_CONFIGS_FILE_PATH].data()
-        return EnvironmentConfigs(
-            clientEnvironmentConfigsData[BASE_URL] ?: "",
-            clientEnvironmentConfigsData[IDENTITY_URL] ?: ""
-        )
+        val baseUrl = clientEnvironmentConfigsData[BASE_URL] ?: EMPTY_STRING
+        val identityUrl = IdentityUrl.from(baseUrl)
+
+        return EnvironmentConfigs(baseUrl, identityUrl)
     }
 }

--- a/src/main/kotlin/com/expediagroup/sdk/core/constants/ClientConstants.kt
+++ b/src/main/kotlin/com/expediagroup/sdk/core/constants/ClientConstants.kt
@@ -18,6 +18,8 @@ package com.expediagroup.sdk.core.constants
 import java.io.File
 
 object ClientConstants {
+    const val EMPTY_STRING = ""
+
     const val AUTHORIZATION_REQUEST_LOCK_DELAY = 20L // TODO: Update me.
 
     const val AUTHORIZATION_HEADER = "Authorization"
@@ -30,13 +32,11 @@ object ClientConstants {
 
     const val CLIENT_CREDENTIALS_HEADER = "client_credentials"
 
-    const val CLIENT_ID = "client_id"
+    const val CLIENT_KEY = "client_key"
 
     const val CLIENT_SECRET = "client_secret"
 
     const val BASE_URL = "base_url"
-
-    const val IDENTITY_URL = "identity_url"
 
     private val OPEN_WORLD_HOME_PATH = "${System.getProperty("user.home")}${File.separator}.openworld${File.separator}"
 

--- a/src/main/kotlin/com/expediagroup/sdk/core/plugin/authentication/AuthenticationConfigs.kt
+++ b/src/main/kotlin/com/expediagroup/sdk/core/plugin/authentication/AuthenticationConfigs.kt
@@ -23,13 +23,13 @@ import io.ktor.client.engine.HttpClientEngineConfig
 data class AuthenticationConfigs(
     override val httpClientConfig: HttpClientConfig<out HttpClientEngineConfig>,
     val clientConfiguration: ClientConfiguration,
-    val identityUrl: String
+    val baseUrl: String
 ) : KtorPluginConfigs(httpClientConfig) {
     companion object {
         fun from(
             httpClientConfig: HttpClientConfig<out HttpClientEngineConfig>,
             clientConfiguration: ClientConfiguration,
-            identityUrl: String
-        ): AuthenticationConfigs = AuthenticationConfigs(httpClientConfig, clientConfiguration, identityUrl)
+            baseUrl: String
+        ): AuthenticationConfigs = AuthenticationConfigs(httpClientConfig, clientConfiguration, IdentityUrl.from(baseUrl))
     }
 }

--- a/src/main/kotlin/com/expediagroup/sdk/core/plugin/authentication/IdentityUrl.kt
+++ b/src/main/kotlin/com/expediagroup/sdk/core/plugin/authentication/IdentityUrl.kt
@@ -1,0 +1,15 @@
+package com.expediagroup.sdk.core.plugin.authentication
+
+object IdentityUrl {
+    private const val IDENTITY_SUFFIX = "/identity/oauth2/v2/token"
+
+    /**
+     * Builds the identity URL for the given [baseUrl], removing any extra slashes.
+     *
+     * @param baseUrl The base URL of the service.
+     * @return The identity URL.
+     */
+    fun from(baseUrl: String): String {
+        return "$baseUrl$IDENTITY_SUFFIX".replace("(?<=[^:\\s])(\\/+\\/)", "/")
+    }
+}

--- a/src/test/kotlin/com/expediagroup/sdk/core/commons/ClientFactory.kt
+++ b/src/test/kotlin/com/expediagroup/sdk/core/commons/ClientFactory.kt
@@ -16,7 +16,7 @@
 package com.expediagroup.sdk.core.commons
 
 import com.expediagroup.sdk.core.client.Client
-import com.expediagroup.sdk.core.commons.TestConstants.CLIENT_ID_TEST_CREDENTIAL
+import com.expediagroup.sdk.core.commons.TestConstants.CLIENT_KEY_TEST_CREDENTIAL
 import com.expediagroup.sdk.core.commons.TestConstants.CLIENT_SECRET_TEST_CREDENTIAL
 import com.expediagroup.sdk.core.commons.TestConstants.TEST_URL
 import com.expediagroup.sdk.core.config.ClientConfiguration
@@ -24,6 +24,7 @@ import com.expediagroup.sdk.core.config.ClientCredentials
 import com.expediagroup.sdk.core.config.Configuration
 import com.expediagroup.sdk.core.config.EnvironmentConfigs
 import com.expediagroup.sdk.core.config.EnvironmentConfigurationProvider
+import com.expediagroup.sdk.core.plugin.authentication.IdentityUrl
 import io.ktor.client.HttpClient
 import io.mockk.every
 import io.mockk.mockkConstructor
@@ -37,14 +38,14 @@ object ClientFactory {
         every { EnvironmentConfigurationProvider.configuration } returns Configuration(
             ClientConfiguration(
                 ClientCredentials(
-                    clientId = CLIENT_ID_TEST_CREDENTIAL,
+                    clientKey = CLIENT_KEY_TEST_CREDENTIAL,
                     clientSecret = CLIENT_SECRET_TEST_CREDENTIAL
                 )
             )
         )
         every { EnvironmentConfigurationProvider.clientEnvironmentConfigs } returns EnvironmentConfigs(
             TEST_URL,
-            TEST_URL
+            IdentityUrl.from(TEST_URL)
         )
     }
 

--- a/src/test/kotlin/com/expediagroup/sdk/core/commons/MockEnginFactory.kt
+++ b/src/test/kotlin/com/expediagroup/sdk/core/commons/MockEnginFactory.kt
@@ -17,7 +17,7 @@ package com.expediagroup.sdk.core.commons
 
 import com.expediagroup.sdk.core.commons.TestConstants.ACCESS_TOKEN
 import com.expediagroup.sdk.core.commons.TestConstants.BAD_REQUEST_ATTRIBUTE
-import com.expediagroup.sdk.core.commons.TestConstants.CLIENT_ID_TEST_CREDENTIAL
+import com.expediagroup.sdk.core.commons.TestConstants.CLIENT_KEY_TEST_CREDENTIAL
 import com.expediagroup.sdk.core.commons.TestConstants.CLIENT_SECRET_TEST_CREDENTIAL
 import com.expediagroup.sdk.core.commons.TestConstants.TEST_URL
 import com.expediagroup.sdk.core.config.EnvironmentConfigurationProvider
@@ -61,7 +61,7 @@ object MockEnginFactory {
     private fun isValidCredentialsRequest(request: HttpRequestData) = request.headers[AUTHORIZATION_HEADER] == "Basic ${
     String(
         Base64.getEncoder().encode(
-            "$CLIENT_ID_TEST_CREDENTIAL:$CLIENT_SECRET_TEST_CREDENTIAL".toByteArray()
+            "$CLIENT_KEY_TEST_CREDENTIAL:$CLIENT_SECRET_TEST_CREDENTIAL".toByteArray()
         )
     )
     }"

--- a/src/test/kotlin/com/expediagroup/sdk/core/commons/TestConstants.kt
+++ b/src/test/kotlin/com/expediagroup/sdk/core/commons/TestConstants.kt
@@ -17,7 +17,7 @@ package com.expediagroup.sdk.core.commons
 
 object TestConstants {
     const val TEST_URL = "https://example.com"
-    const val CLIENT_ID_TEST_CREDENTIAL = "any client ID"
+    const val CLIENT_KEY_TEST_CREDENTIAL = "any client key"
     const val CLIENT_SECRET_TEST_CREDENTIAL = "any client secret"
     const val ACCESS_TOKEN = "test-access-token"
     const val BAD_REQUEST_ATTRIBUTE = "bad-request"

--- a/src/test/kotlin/com/expediagroup/sdk/core/config/provider/FileConfigurationProviderTest.kt
+++ b/src/test/kotlin/com/expediagroup/sdk/core/config/provider/FileConfigurationProviderTest.kt
@@ -15,6 +15,7 @@
  */
 package com.expediagroup.sdk.core.config.provider
 
+import com.expediagroup.sdk.core.constants.ClientConstants.EMPTY_STRING
 import com.expediagroup.sdk.core.exceptions.ConfigurationException
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -29,11 +30,10 @@ class FileConfigurationProviderTest {
         private const val RESOURCE_FILE_PATH = "/test_configuration.properties"
         private const val RESOURCE_FILE_NAME = "test_configuration.properties"
         private const val INVALID_RESOURCE_FILE_NAME = "./wrongfile.name"
-        private const val API_CLIENT_ID_KEY_NAME = "api_credentials.client_id"
-        private const val API_CLIENT_ID_VALUE = "test-client"
+        private const val API_CLIENT_KEY_NAME = "api_credentials.client_key"
+        private const val API_CLIENT_KEY_VALUE = "test-client"
         private const val API_CLIENT_SECRET_KEY_NAME = "api_credentials.client_secret"
         private const val API_CLIENT_SECRET_VALUE = "test-secret"
-        private const val EMPTY_STRING = ""
         private val INVALID_URL = URL("file:/un-exist_file")
     }
 
@@ -52,7 +52,7 @@ class FileConfigurationProviderTest {
         val configurationData = provider[filePath]
         assertNotNull(configurationData)
         assertEquals(configurationData.data()[API_CLIENT_SECRET_KEY_NAME], API_CLIENT_SECRET_VALUE)
-        assertEquals(configurationData.data()[API_CLIENT_ID_KEY_NAME], API_CLIENT_ID_VALUE)
+        assertEquals(configurationData.data()[API_CLIENT_KEY_NAME], API_CLIENT_KEY_VALUE)
     }
 
     @Test
@@ -63,7 +63,7 @@ class FileConfigurationProviderTest {
         val configurationData = provider[filePath]
         assertNotNull(configurationData)
         assertEquals(configurationData.data()[API_CLIENT_SECRET_KEY_NAME], API_CLIENT_SECRET_VALUE)
-        assertEquals(configurationData.data()[API_CLIENT_ID_KEY_NAME], API_CLIENT_ID_VALUE)
+        assertEquals(configurationData.data()[API_CLIENT_KEY_NAME], API_CLIENT_KEY_VALUE)
     }
 
     @Test
@@ -94,18 +94,18 @@ class FileConfigurationProviderTest {
     fun `file configuration provider should load specific configuration keys if passed`() {
         val provider = FileConfigurationProvider()
         val filePath = this::class.java.getResource(RESOURCE_FILE_PATH)?.file.orEmpty()
-        val configurationData = provider[filePath, setOf(API_CLIENT_ID_KEY_NAME)]
+        val configurationData = provider[filePath, setOf(API_CLIENT_KEY_NAME)]
         assertNotNull(configurationData)
-        assertEquals(configurationData.data()[API_CLIENT_ID_KEY_NAME], API_CLIENT_ID_VALUE)
+        assertEquals(configurationData.data()[API_CLIENT_KEY_NAME], API_CLIENT_KEY_VALUE)
         assertNull(configurationData.data()[API_CLIENT_SECRET_KEY_NAME])
     }
 
     @Test
     fun `file configuration provider should load empty configuration keys if passed with an empty path`() {
         val provider = FileConfigurationProvider()
-        val configurationData = provider[EMPTY_STRING, setOf(API_CLIENT_ID_KEY_NAME)]
+        val configurationData = provider[EMPTY_STRING, setOf(API_CLIENT_KEY_NAME)]
         assertNotNull(configurationData)
-        assertNull(configurationData.data()[API_CLIENT_ID_KEY_NAME])
+        assertNull(configurationData.data()[API_CLIENT_KEY_NAME])
         assertNull(configurationData.data()[API_CLIENT_SECRET_KEY_NAME])
     }
 

--- a/src/test/kotlin/com/expediagroup/sdk/core/exceptions/ServiceExceptionTest.kt
+++ b/src/test/kotlin/com/expediagroup/sdk/core/exceptions/ServiceExceptionTest.kt
@@ -30,7 +30,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import java.net.URI
 
-class EgServiceExceptionTest {
+class ServiceExceptionTest {
 
     @Test
     internal fun `request with invalid body should throw an exception`(): Unit = runBlocking {

--- a/src/test/kotlin/com/expediagroup/sdk/core/plugin/authentication/AuthenticationPluginTest.kt
+++ b/src/test/kotlin/com/expediagroup/sdk/core/plugin/authentication/AuthenticationPluginTest.kt
@@ -17,7 +17,7 @@ package com.expediagroup.sdk.core.plugin.authentication
 
 import com.expediagroup.sdk.core.commons.ClientFactory
 import com.expediagroup.sdk.core.commons.TestConstants.ACCESS_TOKEN
-import com.expediagroup.sdk.core.commons.TestConstants.CLIENT_ID_TEST_CREDENTIAL
+import com.expediagroup.sdk.core.commons.TestConstants.CLIENT_KEY_TEST_CREDENTIAL
 import com.expediagroup.sdk.core.commons.TestConstants.CLIENT_SECRET_TEST_CREDENTIAL
 import com.expediagroup.sdk.core.commons.TestConstants.TEST_URL
 import com.expediagroup.sdk.core.config.ClientConfiguration
@@ -58,11 +58,11 @@ class AuthenticationPluginTest {
             assertThrows<ClientException> {
                 AuthenticationPlugin.refreshToken(
                     client,
-                    AuthenticationConfigs(
+                    AuthenticationConfigs.from(
                         HttpClientConfig(),
                         ClientConfiguration(
                             ClientCredentials(
-                                CLIENT_ID_TEST_CREDENTIAL + "invalid",
+                                CLIENT_KEY_TEST_CREDENTIAL + "invalid",
                                 CLIENT_SECRET_TEST_CREDENTIAL + "invalid"
                             )
                         ),

--- a/src/test/resources/test_configuration.properties
+++ b/src/test/resources/test_configuration.properties
@@ -1,2 +1,2 @@
-api_credentials.client_id=test-client
+api_credentials.client_key=test-client
 api_credentials.client_secret=test-secret


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [x] Code is up-to-date with the `main` branch.
* [x] You've successfully built and run the tests locally.
* [ ] There are new or updated unit tests validating the change.

Refer to CONTRIBUTING.md for more details.
-->

### :pencil: Description
IdentityUrl is now shared between all externalized services and based on the BaseURL, thus, we need
to refactor our codebase to build it internally instead of reading it from configurations. We
introduced multiple related code clean-up changes as well.

### :link: Related Issues
#1  