### PR TITLE
fix: switch JSON processor from Gson to Jackson

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
     <artifactId>openworld-java-sdk-core</artifactId>
     <name>EG Open World SDK :: Core</name>
     <description>Core Modules of EG Travel SDK</description>
-    <version>0.0.2-alpha.3</version>
+    <version>0.0.2-alpha.4</version>
 
     <build>
         <plugins>
@@ -173,7 +173,19 @@
     </build>
 
     <dependencies>
-
+        <dependency>
+            <groupId>io.ktor</groupId>
+            <artifactId>ktor-serialization-jackson-jvm</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.datatype</groupId>
+            <artifactId>jackson-datatype-jsr310</artifactId>
+            <scope>runtime</scope>
+        </dependency>
         <dependency>
             <groupId>io.ktor</groupId>
             <artifactId>ktor-client-core-jvm</artifactId>
@@ -213,14 +225,6 @@
         <dependency>
             <groupId>io.ktor</groupId>
             <artifactId>ktor-serialization-jvm</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.ktor</groupId>
-            <artifactId>ktor-serialization-gson-jvm</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>com.google.code.gson</groupId>
-            <artifactId>gson</artifactId>
         </dependency>
 
         <dependency>

--- a/src/main/kotlin/com/expediagroup/sdk/core/plugin/serialization/SerializationPlugin.kt
+++ b/src/main/kotlin/com/expediagroup/sdk/core/plugin/serialization/SerializationPlugin.kt
@@ -16,33 +16,21 @@
 package com.expediagroup.sdk.core.plugin.serialization
 
 import com.expediagroup.sdk.core.plugin.Plugin
-import com.google.gson.FieldNamingPolicy
-import com.google.gson.JsonDeserializer
-import com.google.gson.JsonPrimitive
-import com.google.gson.JsonSerializer
+import com.fasterxml.jackson.databind.DeserializationFeature
+import com.fasterxml.jackson.databind.PropertyNamingStrategies
 import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
-import io.ktor.http.ContentType
-import io.ktor.serialization.gson.gson
-import java.time.OffsetDateTime
+import io.ktor.serialization.jackson.jackson
+import java.text.SimpleDateFormat
 
 internal object SerializationPlugin : Plugin<SerializationConfiguration> {
     override fun install(configurations: SerializationConfiguration) {
         configurations.httpClientConfiguration.install(ContentNegotiation) {
-            when (configurations.contentType.contentSubtype) {
-                ContentType.Application.Json.contentSubtype -> gson {
-                    setFieldNamingPolicy(FieldNamingPolicy.LOWER_CASE_WITH_UNDERSCORES)
-                    setPrettyPrinting().registerTypeAdapter(
-                        OffsetDateTime::class.java,
-                        JsonDeserializer { json, _, _ ->
-                            OffsetDateTime.parse(json.asString)
-                        }
-                    ).registerTypeAdapter(
-                        OffsetDateTime::class.java,
-                        JsonSerializer<OffsetDateTime> { time, _, _ ->
-                            JsonPrimitive(time.toString())
-                        }
-                    )
-                }
+            jackson {
+                this.enable(DeserializationFeature.USE_BIG_DECIMAL_FOR_FLOATS)
+                this.propertyNamingStrategy = PropertyNamingStrategies.SNAKE_CASE
+                this.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+                this.dateFormat = SimpleDateFormat()
+                findAndRegisterModules()
             }
         }
     }

--- a/src/test/kotlin/com/expediagroup/sdk/core/commons/MockEngineFactory.kt
+++ b/src/test/kotlin/com/expediagroup/sdk/core/commons/MockEngineFactory.kt
@@ -72,7 +72,7 @@ object MockEngineFactory {
         content = ByteReadChannel(
             """
                 {
-                    "access_token": $ACCESS_TOKEN,
+                    "access_token": "$ACCESS_TOKEN",
                     "token_type": "bearer",
                     "expires_in": 1800,
                     "scope": "any-scope"

--- a/src/test/kotlin/com/expediagroup/sdk/core/plugin/authentication/AuthenticationPluginTest.kt
+++ b/src/test/kotlin/com/expediagroup/sdk/core/plugin/authentication/AuthenticationPluginTest.kt
@@ -224,7 +224,7 @@ internal class AuthenticationPluginTest {
         content = ByteReadChannel(
             """
                     {
-                        "access_token": $ACCESS_TOKEN,
+                        "access_token": "$ACCESS_TOKEN",
                         "token_type": "bearer",
                         "expires_in": $expiresIn,
                         "scope": "any-scope"


### PR DESCRIPTION
Please verify that:
* [x] Code is up-to-date with the `main` branch.
* [x] You've successfully built and run the tests locally.
* [x] There are new or updated unit tests validating the change.

### :pencil: Description
- Change the JSON processor from Gson to Jackson due to Gson's inability to deserialize interfaces out of the box

### :link: Related Issues
N/A
