### PR TITLE
refactor(error-handling): Reorganize Exceptions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
     <artifactId>openworld-java-sdk-core</artifactId>
     <name>EG Open World SDK :: Core</name>
     <description>Core Modules of EG Travel SDK</description>
-    <version>0.0.3</version>
+    <version>0.0.4</version>
 
     <build>
         <plugins>

--- a/src/main/kotlin/com/expediagroup/sdk/core/client/openapi/OpenApiStub.kt
+++ b/src/main/kotlin/com/expediagroup/sdk/core/client/openapi/OpenApiStub.kt
@@ -20,7 +20,7 @@ import com.expediagroup.sdk.core.configuration.ClientConfiguration
 import com.expediagroup.sdk.core.constant.Constant
 import com.expediagroup.sdk.core.constant.provider.LoggingMessageProvider.getResponseUnsuccessfulMessage
 import com.expediagroup.sdk.core.model.error.Error
-import com.expediagroup.sdk.core.model.exception.ServiceException
+import com.expediagroup.sdk.core.model.exception.service.OpenWorldServiceException
 import io.ktor.client.call.body
 import io.ktor.client.engine.okhttp.OkHttp
 import io.ktor.client.statement.HttpResponse
@@ -59,7 +59,7 @@ abstract class OpenApiStub(
      * Examines the status code for errors and throws the appropriate exception.
      *
      * @param response The response to examine
-     * @throws ServiceException if an error response is received from the service.
+     * @throws OpenWorldServiceException if an error response is received from the service.
      */
     protected suspend fun throwIfError(response: HttpResponse) {
         if (isNotSuccessfulResponse(response)) {
@@ -73,9 +73,9 @@ abstract class OpenApiStub(
         runCatching {
             response.body<Error>()
         }.onSuccess {
-            throw ServiceException(response.status, it)
+            throw OpenWorldServiceException(response.status, it)
         }.onFailure {
-            throw ServiceException(
+            throw OpenWorldServiceException(
                 response.status,
                 Error(response.request.url.toURI(), response.status.description)
             )

--- a/src/main/kotlin/com/expediagroup/sdk/core/client/openapi/RapidOpenApiStub.kt
+++ b/src/main/kotlin/com/expediagroup/sdk/core/client/openapi/RapidOpenApiStub.kt
@@ -18,7 +18,7 @@ package com.expediagroup.sdk.core.client.openapi
 import com.expediagroup.sdk.core.client.Client
 import com.expediagroup.sdk.core.configuration.ClientConfiguration
 import com.expediagroup.sdk.core.model.error.rapid.RapidError
-import com.expediagroup.sdk.core.model.exception.RapidServiceException
+import com.expediagroup.sdk.core.model.exception.rapid.RapidServiceException
 import io.ktor.client.call.body
 import io.ktor.client.engine.okhttp.OkHttp
 import io.ktor.client.statement.HttpResponse

--- a/src/main/kotlin/com/expediagroup/sdk/core/config/Config.kt
+++ b/src/main/kotlin/com/expediagroup/sdk/core/config/Config.kt
@@ -17,7 +17,7 @@ package com.expediagroup.sdk.core.config
 
 import com.expediagroup.sdk.core.config.provider.ConfigurationData
 import com.expediagroup.sdk.core.constant.provider.ExceptionMessageProvider.getConfigurationUnknownMessage
-import com.expediagroup.sdk.core.model.exception.ConfigurationException
+import com.expediagroup.sdk.core.model.exception.client.OpenWorldConfigurationException
 
 /**
  * @property configurationData deserialized configuration data which needs to be parsed
@@ -41,7 +41,7 @@ class Config(
      */
     operator fun get(key: String): Any {
         if (!configurations.containsKey(key)) {
-            throw ConfigurationException(getConfigurationUnknownMessage(key))
+            throw OpenWorldConfigurationException(getConfigurationUnknownMessage(key))
         }
 
         return configurations[key]!!

--- a/src/main/kotlin/com/expediagroup/sdk/core/config/ConfigurationDefinition.kt
+++ b/src/main/kotlin/com/expediagroup/sdk/core/config/ConfigurationDefinition.kt
@@ -20,7 +20,7 @@ import com.expediagroup.sdk.core.constant.provider.ExceptionMessageProvider.getC
 import com.expediagroup.sdk.core.constant.provider.ExceptionMessageProvider.getExpectedActualNameValueMessage
 import com.expediagroup.sdk.core.constant.provider.ExceptionMessageProvider.getExpectedNameValueMessage
 import com.expediagroup.sdk.core.constant.provider.ExceptionMessageProvider.getRequiredConfigurationsNotDefinedMessage
-import com.expediagroup.sdk.core.model.exception.ConfigurationException
+import com.expediagroup.sdk.core.model.exception.client.OpenWorldConfigurationException
 import java.util.Locale
 
 /**
@@ -32,7 +32,7 @@ class ConfigurationDefinition {
 
     private fun define(key: ConfigurationKey): ConfigurationDefinition {
         if (configKeys.containsKey(key.name)) {
-            throw ConfigurationException(getConfigurationDefinedMultipleTimesMessage(key.name))
+            throw OpenWorldConfigurationException(getConfigurationDefinedMultipleTimesMessage(key.name))
         }
         configKeys[key.name] = key
         return this
@@ -78,7 +78,7 @@ class ConfigurationDefinition {
      * @return - configuration key
      */
     fun get(name: String): ConfigurationKey =
-        configKeys[name] ?: throw ConfigurationException(getConfigurationKeyNotDefinedMessage(name))
+        configKeys[name] ?: throw OpenWorldConfigurationException(getConfigurationKeyNotDefinedMessage(name))
 
     /**
      * Parses the configuration values based on the defined keys.
@@ -90,7 +90,7 @@ class ConfigurationDefinition {
         // Check all configurations are defined
         val undefinedConfigKeys: List<String> = undefinedConfigs(props)
         if (undefinedConfigKeys.isNotEmpty()) {
-            throw ConfigurationException(getRequiredConfigurationsNotDefinedMessage(undefinedConfigKeys.joinToString(",")))
+            throw OpenWorldConfigurationException(getRequiredConfigurationsNotDefinedMessage(undefinedConfigKeys.joinToString(",")))
         }
         // parse all known keys
         val values: MutableMap<String, Any> = HashMap()
@@ -127,37 +127,37 @@ class ConfigurationDefinition {
     private fun parseBoolean(value: Any, name: String): Boolean {
         toBooleanOrNull(value)?.let { return it }
 
-        throw ConfigurationException(getExpectedNameValueMessage("boolean", name, value))
+        throw OpenWorldConfigurationException(getExpectedNameValueMessage("boolean", name, value))
     }
 
     private fun parsePassword(value: Any, name: String): ConfigurationKey.Password {
         toPasswordOrNull(value)?.let { return it }
 
-        throw ConfigurationException(getExpectedActualNameValueMessage("string", value.javaClass.name, name, value))
+        throw OpenWorldConfigurationException(getExpectedActualNameValueMessage("string", value.javaClass.name, name, value))
     }
 
     private fun parseString(value: Any, name: String): String {
         toStringOrNull(value)?.let { return it }
 
-        throw ConfigurationException(getExpectedActualNameValueMessage("string", value.javaClass.name, name, value))
+        throw OpenWorldConfigurationException(getExpectedActualNameValueMessage("string", value.javaClass.name, name, value))
     }
 
     private fun parseInt(value: Any, name: String): Int {
         toIntOrNull(value)?.let { return it }
 
-        throw ConfigurationException(getExpectedActualNameValueMessage("32-bit integer", value.javaClass.name, name, value))
+        throw OpenWorldConfigurationException(getExpectedActualNameValueMessage("32-bit integer", value.javaClass.name, name, value))
     }
 
     private fun parseDouble(value: Any, name: String): Double {
         toDoubleOrNull(value)?.let { return it }
 
-        throw ConfigurationException(getExpectedActualNameValueMessage("double", value.javaClass.name, name, value))
+        throw OpenWorldConfigurationException(getExpectedActualNameValueMessage("double", value.javaClass.name, name, value))
     }
 
     private fun parseList(value: Any, name: String): List<*> {
         toListOrNull(value)?.let { return it }
 
-        throw ConfigurationException(getExpectedNameValueMessage("comma-separated list", name, value))
+        throw OpenWorldConfigurationException(getExpectedNameValueMessage("comma-separated list", name, value))
     }
 
     private fun toBooleanOrNull(value: Any): Boolean? = when (value) {

--- a/src/main/kotlin/com/expediagroup/sdk/core/config/provider/FileConfigurationProvider.kt
+++ b/src/main/kotlin/com/expediagroup/sdk/core/config/provider/FileConfigurationProvider.kt
@@ -17,7 +17,7 @@ package com.expediagroup.sdk.core.config.provider
 
 import com.expediagroup.sdk.core.constant.ExceptionMessage.NOT_YET_IMPLEMENTED
 import com.expediagroup.sdk.core.constant.provider.ExceptionMessageProvider.getPropertyNotFoundMessage
-import com.expediagroup.sdk.core.model.exception.ConfigurationException
+import com.expediagroup.sdk.core.model.exception.client.OpenWorldConfigurationException
 import org.slf4j.LoggerFactory
 import java.io.BufferedReader
 import java.io.IOException
@@ -55,7 +55,7 @@ class FileConfigurationProvider : ConfigurationProvider {
             return readPropsFileIntoConfigurationData(getReader(path))
         }.getOrElse {
             if (!optional) {
-                throw ConfigurationException(getPropertyNotFoundMessage(path))
+                throw OpenWorldConfigurationException(getPropertyNotFoundMessage(path))
             }
 
             return emptyConfigurationData
@@ -74,7 +74,7 @@ class FileConfigurationProvider : ConfigurationProvider {
         return runCatching {
             readPropsFileIntoConfigurationData(getReader(url))
         }.getOrElse {
-            if (!optional) throw ConfigurationException(getPropertyNotFoundMessage(url))
+            if (!optional) throw OpenWorldConfigurationException(getPropertyNotFoundMessage(url))
 
             return emptyConfigurationData
         }
@@ -123,7 +123,7 @@ class FileConfigurationProvider : ConfigurationProvider {
             }
         } catch (e: IOException) {
             if (!optional) {
-                throw ConfigurationException(getPropertyNotFoundMessage(path), e)
+                throw OpenWorldConfigurationException(getPropertyNotFoundMessage(path), e)
             }
 
             return emptyConfigurationData

--- a/src/main/kotlin/com/expediagroup/sdk/core/model/exception/client/OpenWorldClientException.kt
+++ b/src/main/kotlin/com/expediagroup/sdk/core/model/exception/client/OpenWorldClientException.kt
@@ -13,12 +13,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.expediagroup.sdk.core.model.exception
+package com.expediagroup.sdk.core.model.exception.client
+
+import com.expediagroup.sdk.core.model.exception.OpenWorldException
 
 /**
- * An exception that is thrown when a configuration error occurs.
- *
- * @param message An optional error message.
- * @param cause An optional cause of the error.
+ * An exception that is thrown when a client error occurs.
  */
-class ConfigurationException(message: String?, cause: Throwable? = null) : OpenWorldException(message, cause)
+sealed class OpenWorldClientException(
+    message: String?,
+    cause: Throwable? = null
+) : OpenWorldException(message, cause)

--- a/src/main/kotlin/com/expediagroup/sdk/core/model/exception/client/OpenWorldConfigurationException.kt
+++ b/src/main/kotlin/com/expediagroup/sdk/core/model/exception/client/OpenWorldConfigurationException.kt
@@ -13,18 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.expediagroup.sdk.core.model.exception
-
-import com.expediagroup.sdk.core.model.error.rapid.RapidError
-import io.ktor.http.HttpStatusCode
+package com.expediagroup.sdk.core.model.exception.client
 
 /**
- *  An exception that is thrown when a Rapid service error occurs.
+ * An exception that is thrown when a configuration error occurs.
  *
- *  @param errorCode The HTTP status code of the error.
- *  @param error The error details.
+ * @param message An optional error message.
+ * @param cause An optional cause of the error.
  */
-class RapidServiceException(
-    errorCode: HttpStatusCode,
-    error: RapidError
-) : OpenWorldException("[${errorCode.value}] $error")
+class OpenWorldConfigurationException(message: String?, cause: Throwable? = null) : OpenWorldClientException(message, cause)

--- a/src/main/kotlin/com/expediagroup/sdk/core/model/exception/rapid/RapidServiceException.kt
+++ b/src/main/kotlin/com/expediagroup/sdk/core/model/exception/rapid/RapidServiceException.kt
@@ -13,14 +13,19 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.expediagroup.sdk.core.model.exception
+package com.expediagroup.sdk.core.model.exception.rapid
 
+import com.expediagroup.sdk.core.model.error.rapid.RapidError
+import com.expediagroup.sdk.core.model.exception.OpenWorldException
 import io.ktor.http.HttpStatusCode
 
 /**
- * An exception that is thrown when an authentication error occurs.
+ *  An exception that is thrown when a Rapid service error occurs.
  *
- * @param statusCode The HTTP status code of the error.
- * @param message The error message.
+ *  @param errorCode The HTTP status code of the error.
+ *  @param error The error details.
  */
-class AuthException(statusCode: HttpStatusCode, message: String) : OpenWorldException("[${statusCode.value}] $message")
+class RapidServiceException(
+    errorCode: HttpStatusCode,
+    error: RapidError
+) : OpenWorldException("[${errorCode.value}] $error")

--- a/src/main/kotlin/com/expediagroup/sdk/core/model/exception/service/OpenWorldAuthException.kt
+++ b/src/main/kotlin/com/expediagroup/sdk/core/model/exception/service/OpenWorldAuthException.kt
@@ -13,15 +13,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.expediagroup.sdk.core.model.exception
+package com.expediagroup.sdk.core.model.exception.service
+
+import io.ktor.http.HttpStatusCode
 
 /**
- * A base exception for all SDK exceptions.
+ * An exception that is thrown when an authentication error occurs.
  *
- * @param message An optional error message.
- * @param cause An optional cause of the error.
+ * @param errorCode The HTTP status code of the error.
+ * @param message The error message.
  */
-open class OpenWorldException(
-    message: String?,
-    cause: Throwable? = null
-) : RuntimeException(message, cause)
+class OpenWorldAuthException(errorCode: HttpStatusCode, message: String) : OpenWorldServiceException("[${errorCode.value}] $message")

--- a/src/main/kotlin/com/expediagroup/sdk/core/model/exception/service/OpenWorldServiceException.kt
+++ b/src/main/kotlin/com/expediagroup/sdk/core/model/exception/service/OpenWorldServiceException.kt
@@ -13,18 +13,31 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.expediagroup.sdk.core.model.exception
+package com.expediagroup.sdk.core.model.exception.service
 
 import com.expediagroup.sdk.core.model.error.Error
+import com.expediagroup.sdk.core.model.exception.OpenWorldException
 import io.ktor.http.HttpStatusCode
 
 /**
  * An exception that is thrown when a service error occurs.
  *
- * @param errorCode The HTTP status code of the error.
- * @param error The error details.
+ * @param message An optional error message.
+ * @param cause An optional cause of the error.
  */
-class ServiceException(
-    errorCode: HttpStatusCode,
-    error: Error
-) : OpenWorldException("[${errorCode.value}] $error")
+open class OpenWorldServiceException(
+    message: String?,
+    cause: Throwable? = null
+) : OpenWorldException(message, cause) {
+
+    /**
+     * An exception that is thrown when a service error occurs.
+     *
+     * @param errorCode The HTTP status code of the error.
+     * @param error The error object.
+     */
+    constructor(
+        errorCode: HttpStatusCode,
+        error: Error
+    ) : this("[${errorCode.value}] $error")
+}

--- a/src/main/kotlin/com/expediagroup/sdk/core/plugin/authentication/strategies/bearer/BearerStrategy.kt
+++ b/src/main/kotlin/com/expediagroup/sdk/core/plugin/authentication/strategies/bearer/BearerStrategy.kt
@@ -23,7 +23,7 @@ import com.expediagroup.sdk.core.constant.HeaderKey
 import com.expediagroup.sdk.core.constant.HeaderValue
 import com.expediagroup.sdk.core.constant.LoggingMessage
 import com.expediagroup.sdk.core.constant.provider.LoggingMessageProvider
-import com.expediagroup.sdk.core.model.exception.AuthException
+import com.expediagroup.sdk.core.model.exception.service.OpenWorldAuthException
 import com.expediagroup.sdk.core.plugin.authentication.AuthenticationConfiguration
 import com.expediagroup.sdk.core.plugin.authentication.strategies.AuthenticationStrategy
 import io.ktor.client.HttpClient
@@ -70,7 +70,7 @@ internal object BearerStrategy : AuthenticationStrategy {
             basicAuth(configs.credentials)
         }
         if (renewTokenResponse.status.value !in Constant.SUCCESSFUL_STATUS_CODES_RANGE) {
-            throw AuthException(renewTokenResponse.status, ExceptionMessage.AUTHENTICATION_FAILURE)
+            throw OpenWorldAuthException(renewTokenResponse.status, ExceptionMessage.AUTHENTICATION_FAILURE)
         }
         val renewedTokenInfo: TokenResponse = renewTokenResponse.body()
         log.info(LoggingMessage.TOKEN_RENEWAL_SUCCESSFUL)

--- a/src/test/kotlin/com/expediagroup/sdk/core/commons/MockEngineFactory.kt
+++ b/src/test/kotlin/com/expediagroup/sdk/core/commons/MockEngineFactory.kt
@@ -27,7 +27,7 @@ import com.expediagroup.sdk.core.configuration.provider.DefaultConfigurationProv
 import com.expediagroup.sdk.core.constant.Authentication.BEARER
 import com.expediagroup.sdk.core.constant.Constant.EMPTY_STRING
 import com.expediagroup.sdk.core.constant.HeaderKey
-import com.expediagroup.sdk.core.model.exception.AuthException
+import com.expediagroup.sdk.core.model.exception.service.OpenWorldAuthException
 import io.ktor.client.engine.HttpClientEngine
 import io.ktor.client.engine.mock.MockEngine
 import io.ktor.client.engine.mock.MockRequestHandleScope
@@ -53,7 +53,7 @@ object MockEngineFactory {
         } else if (isBadRequest(request)) {
             errorResponse()
         } else {
-            throw AuthException(HttpStatusCode.InternalServerError, "unsupported case in the mock engine")
+            throw OpenWorldAuthException(HttpStatusCode.InternalServerError, "unsupported case in the mock engine")
         }
     }
 

--- a/src/test/kotlin/com/expediagroup/sdk/core/config/ConfigTest.kt
+++ b/src/test/kotlin/com/expediagroup/sdk/core/config/ConfigTest.kt
@@ -16,7 +16,7 @@
 package com.expediagroup.sdk.core.config
 
 import com.expediagroup.sdk.core.config.provider.FileConfigurationProvider
-import com.expediagroup.sdk.core.model.exception.ConfigurationException
+import com.expediagroup.sdk.core.model.exception.client.OpenWorldConfigurationException
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
@@ -130,7 +130,7 @@ class ConfigTest {
             importance = ConfigurationKey.Importance.HIGH
         )
         val provider = FileConfigurationProvider()
-        val throwable = assertThrows<ConfigurationException> {
+        val throwable = assertThrows<OpenWorldConfigurationException> {
             Config(provider[filePath], configurationDefinition)
         }
         assertEquals(throwable.message, "Some required configurations are not defined: missing_configuration")
@@ -143,7 +143,7 @@ class ConfigTest {
         val provider = FileConfigurationProvider()
         val configuration = Config(provider[filePath], configurationDefinition)
 
-        val throwable = assertThrows<ConfigurationException> {
+        val throwable = assertThrows<OpenWorldConfigurationException> {
             configuration.getDouble(EXEMPLAR_API_CLIENT_VERSION_NAME)
         }
         assertEquals(throwable.message, "Unknown configuration exemplar_api.client.version")
@@ -167,7 +167,7 @@ class ConfigTest {
             importance = ConfigurationKey.Importance.HIGH
         )
         val provider = FileConfigurationProvider()
-        val throwable = assertThrows<ConfigurationException> {
+        val throwable = assertThrows<OpenWorldConfigurationException> {
             Config(provider[filePath], configurationDefinition)
         }
         assertEquals(throwable.message, "Expected value to be a 32-bit integer, but it was a java.lang.String, name: api_credentials.client_key, value: test-client")

--- a/src/test/kotlin/com/expediagroup/sdk/core/config/ConfigurationDefinitionTest.kt
+++ b/src/test/kotlin/com/expediagroup/sdk/core/config/ConfigurationDefinitionTest.kt
@@ -15,7 +15,7 @@
  */
 package com.expediagroup.sdk.core.config
 
-import com.expediagroup.sdk.core.model.exception.ConfigurationException
+import com.expediagroup.sdk.core.model.exception.client.OpenWorldConfigurationException
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertNull
@@ -236,7 +236,7 @@ class ConfigurationDefinitionTest {
             type = configurationType,
             importance = configurationImportance
         )
-        val throwable = assertThrows<ConfigurationException> {
+        val throwable = assertThrows<OpenWorldConfigurationException> {
             configurationDefinition.parse(mapOf())
         }
         assertEquals("Some required configurations are not defined: $configurationName", throwable.message)
@@ -255,7 +255,7 @@ class ConfigurationDefinitionTest {
             type = configurationType,
             importance = configurationImportance
         )
-        val throwable = assertThrows<ConfigurationException> {
+        val throwable = assertThrows<OpenWorldConfigurationException> {
             configurationDefinition.define(
                 name = configurationName,
                 documentation = configurationDocumentation,
@@ -279,7 +279,7 @@ class ConfigurationDefinitionTest {
             importance = configurationImportance
         )
 
-        val throwableWhenInvalidString = assertThrows<ConfigurationException> {
+        val throwableWhenInvalidString = assertThrows<OpenWorldConfigurationException> {
             configurationDefinition.parse(mapOf(booleanConfigurationName to "invalid"))
         }
         assertEquals(
@@ -301,7 +301,7 @@ class ConfigurationDefinitionTest {
             importance = configurationImportance
         )
 
-        val throwableWhenInvalidInt = assertThrows<ConfigurationException> {
+        val throwableWhenInvalidInt = assertThrows<OpenWorldConfigurationException> {
             configurationDefinition.parse(mapOf(booleanConfigurationName to 213))
         }
         assertEquals(
@@ -324,7 +324,7 @@ class ConfigurationDefinitionTest {
             importance = configurationImportance
         )
 
-        val throwable = assertThrows<ConfigurationException> {
+        val throwable = assertThrows<OpenWorldConfigurationException> {
             configurationDefinition.parse(props)
         }
         assertEquals(
@@ -347,14 +347,14 @@ class ConfigurationDefinitionTest {
             importance = configurationImportance
         )
 
-        val throwableWhenInvalidString = assertThrows<ConfigurationException> {
+        val throwableWhenInvalidString = assertThrows<OpenWorldConfigurationException> {
             configurationDefinition.parse(props)
         }
         assertEquals(
             "Expected value to be a 32-bit integer, but it was a java.lang.String, name: $configurationName, value: invalid",
             throwableWhenInvalidString.message
         )
-        val throwableWhenInvalidBoolean = assertThrows<ConfigurationException> {
+        val throwableWhenInvalidBoolean = assertThrows<OpenWorldConfigurationException> {
             configurationDefinition.parse(mapOf(configurationName to true))
         }
         assertEquals(
@@ -375,14 +375,14 @@ class ConfigurationDefinitionTest {
             type = ConfigurationKey.Type.DOUBLE,
             importance = configurationImportance
         )
-        val throwableWhenInvalidString = assertThrows<ConfigurationException> {
+        val throwableWhenInvalidString = assertThrows<OpenWorldConfigurationException> {
             configurationDefinition.parse(mapOf(configurationName to "invalid"))
         }
         assertEquals(
             "Expected value to be a double, but it was a java.lang.String, name: $configurationName, value: invalid",
             throwableWhenInvalidString.message
         )
-        val throwableWhenInvalidBoolean = assertThrows<ConfigurationException> {
+        val throwableWhenInvalidBoolean = assertThrows<OpenWorldConfigurationException> {
             configurationDefinition.parse(mapOf(configurationName to true))
         }
         assertEquals(
@@ -405,7 +405,7 @@ class ConfigurationDefinitionTest {
             importance = configurationImportance
         )
 
-        val throwable = assertThrows<ConfigurationException> {
+        val throwable = assertThrows<OpenWorldConfigurationException> {
             configurationDefinition.parse(props)
         }
         assertEquals(
@@ -428,7 +428,7 @@ class ConfigurationDefinitionTest {
             importance = configurationImportance
         )
 
-        val throwable = assertThrows<ConfigurationException> {
+        val throwable = assertThrows<OpenWorldConfigurationException> {
             configurationDefinition.parse(props)
         }
         assertEquals(
@@ -442,7 +442,7 @@ class ConfigurationDefinitionTest {
         val configurationDefinition = ConfigurationDefinition()
         val listConfigurationName = "list_configuration"
 
-        val throwable = assertThrows<ConfigurationException> {
+        val throwable = assertThrows<OpenWorldConfigurationException> {
             configurationDefinition.get(listConfigurationName)
         }
         assertEquals("Configuration key not defined, name: $listConfigurationName", throwable.message)
@@ -461,7 +461,7 @@ class ConfigurationDefinitionTest {
                 if (regex.matches(value as String)) {
                     return value
                 }
-                throw ConfigurationException("value is not uppercase")
+                throw OpenWorldConfigurationException("value is not uppercase")
             }
         }
         configurationDefinition.define(
@@ -472,7 +472,7 @@ class ConfigurationDefinitionTest {
             validator = validator
         )
 
-        val throwable = assertThrows<ConfigurationException> {
+        val throwable = assertThrows<OpenWorldConfigurationException> {
             configurationDefinition.parse(props)
         }
         assertEquals("value is not uppercase", throwable.message)

--- a/src/test/kotlin/com/expediagroup/sdk/core/config/provider/FileConfigurationProviderTest.kt
+++ b/src/test/kotlin/com/expediagroup/sdk/core/config/provider/FileConfigurationProviderTest.kt
@@ -16,7 +16,7 @@
 package com.expediagroup.sdk.core.config.provider
 
 import com.expediagroup.sdk.core.constant.Constant.EMPTY_STRING
-import com.expediagroup.sdk.core.model.exception.ConfigurationException
+import com.expediagroup.sdk.core.model.exception.client.OpenWorldConfigurationException
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
@@ -69,7 +69,7 @@ class FileConfigurationProviderTest {
     @Test
     fun `file configuration provider should throw configuration exception if the file is not found`() {
         val provider: ConfigurationProvider = FileConfigurationProvider()
-        assertThrows<ConfigurationException> {
+        assertThrows<OpenWorldConfigurationException> {
             provider[INVALID_RESOURCE_FILE_NAME]
         }
     }
@@ -77,7 +77,7 @@ class FileConfigurationProviderTest {
     @Test
     fun `file configuration provider with specific keys should throw configuration exception if the file is not found`() {
         val provider: ConfigurationProvider = FileConfigurationProvider()
-        assertThrows<ConfigurationException> {
+        assertThrows<OpenWorldConfigurationException> {
             provider[INVALID_RESOURCE_FILE_NAME, setOf(API_CLIENT_SECRET_KEY_NAME)]
         }
     }
@@ -85,7 +85,7 @@ class FileConfigurationProviderTest {
     @Test
     fun `file configuration provider should throw configuration exception if the file url is not found`() {
         val provider: ConfigurationProvider = FileConfigurationProvider()
-        assertThrows<ConfigurationException> {
+        assertThrows<OpenWorldConfigurationException> {
             provider[INVALID_URL]
         }
     }
@@ -100,7 +100,7 @@ class FileConfigurationProviderTest {
     fun `file configuration provider should throw an exception when the optional flag is not set and file doesn't exists`() {
         val provider: ConfigurationProvider = FileConfigurationProvider()
 
-        assertThrows<ConfigurationException> {
+        assertThrows<OpenWorldConfigurationException> {
             provider[INVALID_URL].data()
         }
     }

--- a/src/test/kotlin/com/expediagroup/sdk/core/configuration/provider/FileSystemConfigurationProviderTest.kt
+++ b/src/test/kotlin/com/expediagroup/sdk/core/configuration/provider/FileSystemConfigurationProviderTest.kt
@@ -17,7 +17,7 @@ package com.expediagroup.sdk.core.configuration.provider
 
 import com.expediagroup.sdk.core.constant.Constant
 import com.expediagroup.sdk.core.constant.Constant.EMPTY_STRING
-import com.expediagroup.sdk.core.model.exception.ConfigurationException
+import com.expediagroup.sdk.core.model.exception.client.OpenWorldConfigurationException
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertNull
@@ -43,7 +43,7 @@ internal class FileSystemConfigurationProviderTest {
 
     @Test
     fun `should throw an exception when paths are set but files do not exist`() {
-        assertThrows<ConfigurationException> {
+        assertThrows<OpenWorldConfigurationException> {
             FileSystemConfigurationProvider(
                 credentialsFilePath = "invalid_path",
                 configurationsFilePath = "invalid_path"
@@ -84,7 +84,7 @@ internal class FileSystemConfigurationProviderTest {
     fun `test default configurations if default files do not exist`() {
         if (File(Constant.CREDENTIALS_FILE_PATH).exists() && File(Constant.CLIENT_CONFIGS_FILE_PATH).exists()) return
 
-        assertThrows<ConfigurationException> {
+        assertThrows<OpenWorldConfigurationException> {
             FileSystemConfigurationProvider().key
         }
     }

--- a/src/test/kotlin/com/expediagroup/sdk/core/exception/OpenWorldOpenWorldServiceExceptionTest.kt
+++ b/src/test/kotlin/com/expediagroup/sdk/core/exception/OpenWorldOpenWorldServiceExceptionTest.kt
@@ -30,7 +30,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import java.net.URI
 
-class ServiceExceptionTest {
+class OpenWorldOpenWorldServiceExceptionTest {
 
     @Test
     internal fun `request with invalid body should throw an exception`() {

--- a/src/test/kotlin/com/expediagroup/sdk/core/plugin/authentication/AuthenticationPluginTest.kt
+++ b/src/test/kotlin/com/expediagroup/sdk/core/plugin/authentication/AuthenticationPluginTest.kt
@@ -29,7 +29,7 @@ import com.expediagroup.sdk.core.configuration.provider.DefaultConfigurationProv
 import com.expediagroup.sdk.core.constant.Authentication.BEARER
 import com.expediagroup.sdk.core.constant.Authentication.EAN
 import com.expediagroup.sdk.core.constant.HeaderKey
-import com.expediagroup.sdk.core.model.exception.AuthException
+import com.expediagroup.sdk.core.model.exception.service.OpenWorldAuthException
 import com.expediagroup.sdk.core.plugin.Hooks
 import com.expediagroup.sdk.core.plugin.authentication.helper.SuccessfulStatusCodesArgumentProvider
 import com.expediagroup.sdk.core.plugin.authentication.helper.UnsuccessfulStatusCodesArgumentProvider
@@ -170,7 +170,7 @@ internal class AuthenticationPluginTest {
             runBlocking {
                 val httpClient = ClientFactory.createClient(createUnauthorizedMockEngineWithStatusCode(httpStatusCode)).httpClient
 
-                assertThrows<AuthException> {
+                assertThrows<OpenWorldAuthException> {
                     AuthenticationPlugin.renewToken(
                         httpClient,
                         AuthenticationConfiguration.from(


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [x] Code is up-to-date with the `main` branch.
* [x] You've successfully built and run the tests locally.
* [ ] There are new or updated unit tests validating the change.

Refer to CONTRIBUTING.md for more details.
-->

### :pencil: Description
- Reorganize our exceptions tree to have the following:
  - `OpenWorldException`: Our base exception.
  - `OpenWorldServiceException`: Any exception caused by our services.
  - `OpenWorldClientException`: Any exception caused by the client.

- Any exceptions we throw will extend from the exceptions defined above.

- Other changes:
  - Rename all exceptions to have the 'OpenWorld' prefix.
  - Move the new exceptions to new packages:  client & service.
  - The `OpenWorldAuthException` is inherited from `OpenWorldServiceException` instead of the base `OpenWorldException`.

**BREAKING CHANGE**: Exceptions have been reorganized.


### :link: Related Issues
N/A
