### PR TITLE
chore(validation): Unseal OpenWorldClientException Class

### DIFF
--- a/src/main/kotlin/com/expediagroup/sdk/core/model/exception/client/OpenWorldClientException.kt
+++ b/src/main/kotlin/com/expediagroup/sdk/core/model/exception/client/OpenWorldClientException.kt
@@ -20,7 +20,7 @@ import com.expediagroup.sdk.core.model.exception.OpenWorldException
 /**
  * An exception that is thrown when a client error occurs.
  */
-sealed class OpenWorldClientException(
+class OpenWorldClientException(
     message: String?,
     cause: Throwable? = null
 ) : OpenWorldException(message, cause)

--- a/src/main/kotlin/com/expediagroup/sdk/core/model/exception/client/OpenWorldClientException.kt
+++ b/src/main/kotlin/com/expediagroup/sdk/core/model/exception/client/OpenWorldClientException.kt
@@ -20,7 +20,7 @@ import com.expediagroup.sdk.core.model.exception.OpenWorldException
 /**
  * An exception that is thrown when a client error occurs.
  */
-class OpenWorldClientException(
+open class OpenWorldClientException(
     message: String?,
     cause: Throwable? = null
 ) : OpenWorldException(message, cause)


### PR DESCRIPTION
* [x] Code is up-to-date with the `main` branch.
* [x] You've successfully built and run the tests locally.
* [ ] There are new or updated unit tests validating the change.

### :pencil: Description
- Unseal OpenWorldClientException class

### :link: Related Issues
- PR: https://github.com/ExpediaGroup/openworld-sdk-java-generators/pull/30
