### PR TITLE
feat(error-handling): Expose Error Object In OpenWorldServiceException

### DIFF
--- a/src/main/kotlin/com/expediagroup/sdk/core/model/exception/rapid/RapidServiceException.kt
+++ b/src/main/kotlin/com/expediagroup/sdk/core/model/exception/rapid/RapidServiceException.kt
@@ -22,10 +22,10 @@ import io.ktor.http.HttpStatusCode
 /**
  *  An exception that is thrown when a Rapid service error occurs.
  *
- *  @param errorCode The HTTP status code of the error.
- *  @param error The error details.
+ *  @property errorCode The HTTP status code of the error.
+ *  @property error The error details.
  */
 class RapidServiceException(
-    errorCode: HttpStatusCode,
-    error: RapidError
+    val errorCode: HttpStatusCode,
+    val error: RapidError
 ) : OpenWorldException("[${errorCode.value}] $error")

--- a/src/main/kotlin/com/expediagroup/sdk/core/model/exception/service/OpenWorldAuthException.kt
+++ b/src/main/kotlin/com/expediagroup/sdk/core/model/exception/service/OpenWorldAuthException.kt
@@ -23,4 +23,4 @@ import io.ktor.http.HttpStatusCode
  * @param errorCode The HTTP status code of the error.
  * @param message The error message.
  */
-class OpenWorldAuthException(errorCode: HttpStatusCode, message: String) : OpenWorldServiceException("[${errorCode.value}] $message")
+class OpenWorldAuthException(errorCode: HttpStatusCode, message: String) : OpenWorldServiceException(message = "[${errorCode.value}] $message", errorCode = errorCode)

--- a/src/main/kotlin/com/expediagroup/sdk/core/model/exception/service/OpenWorldServiceException.kt
+++ b/src/main/kotlin/com/expediagroup/sdk/core/model/exception/service/OpenWorldServiceException.kt
@@ -22,12 +22,16 @@ import io.ktor.http.HttpStatusCode
 /**
  * An exception that is thrown when a service error occurs.
  *
- * @param message An optional error message.
- * @param cause An optional cause of the error.
+ * @property message An optional error message.
+ * @property cause An optional cause of the error.
+ * @property errorCode The HTTP status code of the error.
+ * @property error The error object.
  */
 open class OpenWorldServiceException(
-    message: String?,
-    cause: Throwable? = null
+    override val message: String?,
+    override val cause: Throwable? = null,
+    val errorCode: HttpStatusCode,
+    val error: Error? = null
 ) : OpenWorldException(message, cause) {
 
     /**
@@ -39,5 +43,5 @@ open class OpenWorldServiceException(
     constructor(
         errorCode: HttpStatusCode,
         error: Error
-    ) : this("[${errorCode.value}] $error")
+    ) : this(message = "[${errorCode.value}] $error", errorCode = errorCode, error = error)
 }

--- a/src/main/kotlin/com/expediagroup/sdk/core/model/exception/service/OpenWorldServiceException.kt
+++ b/src/main/kotlin/com/expediagroup/sdk/core/model/exception/service/OpenWorldServiceException.kt
@@ -28,8 +28,8 @@ import io.ktor.http.HttpStatusCode
  * @property error The error object.
  */
 open class OpenWorldServiceException(
-    override val message: String?,
-    override val cause: Throwable? = null,
+    message: String?,
+    cause: Throwable? = null,
     val errorCode: HttpStatusCode,
     val error: Error? = null
 ) : OpenWorldException(message, cause) {

--- a/src/main/kotlin/com/expediagroup/sdk/core/model/exception/service/OpenWorldServiceException.kt
+++ b/src/main/kotlin/com/expediagroup/sdk/core/model/exception/service/OpenWorldServiceException.kt
@@ -22,8 +22,8 @@ import io.ktor.http.HttpStatusCode
 /**
  * An exception that is thrown when a service error occurs.
  *
- * @property message An optional error message.
- * @property cause An optional cause of the error.
+ * @param message An optional error message.
+ * @param cause An optional cause of the error.
  * @property errorCode The HTTP status code of the error.
  * @property error The error object.
  */

--- a/src/test/kotlin/com/expediagroup/sdk/core/plugin/authentication/AuthenticationPluginTest.kt
+++ b/src/test/kotlin/com/expediagroup/sdk/core/plugin/authentication/AuthenticationPluginTest.kt
@@ -28,6 +28,7 @@ import com.expediagroup.sdk.core.configuration.Credentials
 import com.expediagroup.sdk.core.configuration.provider.DefaultConfigurationProvider
 import com.expediagroup.sdk.core.constant.Authentication.BEARER
 import com.expediagroup.sdk.core.constant.Authentication.EAN
+import com.expediagroup.sdk.core.constant.ExceptionMessage
 import com.expediagroup.sdk.core.constant.HeaderKey
 import com.expediagroup.sdk.core.model.exception.service.OpenWorldAuthException
 import com.expediagroup.sdk.core.plugin.Hooks
@@ -170,7 +171,7 @@ internal class AuthenticationPluginTest {
             runBlocking {
                 val httpClient = ClientFactory.createClient(createUnauthorizedMockEngineWithStatusCode(httpStatusCode)).httpClient
 
-                assertThrows<OpenWorldAuthException> {
+                val exception = assertThrows<OpenWorldAuthException> {
                     AuthenticationPlugin.renewToken(
                         httpClient,
                         AuthenticationConfiguration.from(
@@ -183,6 +184,10 @@ internal class AuthenticationPluginTest {
                         )
                     )
                 }
+                assertThat(exception.message).isEqualTo("[${httpStatusCode.value}] ${ExceptionMessage.AUTHENTICATION_FAILURE}")
+                assertThat(exception.cause).isNull()
+                assertThat(exception.errorCode).isEqualTo(httpStatusCode)
+                assertThat(exception.error).isNull()
 
                 clearBearerTokens(httpClient)
             }


### PR DESCRIPTION
* [x] Code is up-to-date with the `main` branch.
* [x] You've successfully built and run the tests locally.
* [x] There are new or updated unit tests validating the change.

### :pencil: Description
- Expose Error object in OpenWorldServiceException

### :link: Related Issues
N/A
