### PR TITLE
refactor(core): Split the Core - Step 7

### DIFF
--- a/src/main/kotlin/com/expediagroup/common/sdk/core/client/Client.kt
+++ b/src/main/kotlin/com/expediagroup/common/sdk/core/client/Client.kt
@@ -39,7 +39,7 @@ import com.expediagroup.common.sdk.core.plugin.serialization.SerializationConfig
 import com.expediagroup.common.sdk.core.plugin.serialization.SerializationPlugin
 import com.expediagroup.openworld.sdk.core.client.OpenWorldClient
 import com.expediagroup.openworld.sdk.core.configuration.OpenWorldClientConfiguration
-import com.expediagroup.rapid.sdk.core.client.RapidClient
+import com.expediagroup.rapid.sdk.core.client.BaseRapidClient
 import com.expediagroup.rapid.sdk.core.configuration.RapidClientConfiguration
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.HttpClientEngine
@@ -123,7 +123,7 @@ abstract class Client {
             httpClientEngine: HttpClientEngine = DEFAULT_HTTP_CLIENT_ENGINE
         ): C = when (C::class) {
             OpenWorldClient::class -> OpenWorldClient(clientConfiguration as OpenWorldClientConfiguration, httpClientEngine) as C
-            RapidClient::class -> RapidClient(clientConfiguration as RapidClientConfiguration, httpClientEngine) as C
+            BaseRapidClient::class -> BaseRapidClient(clientConfiguration as RapidClientConfiguration, httpClientEngine) as C
             else -> throw IllegalArgumentException("Unsupported client type: ${C::class.simpleName}")
         }
     }

--- a/src/main/kotlin/com/expediagroup/rapid/sdk/core/client/BaseRapidClient.kt
+++ b/src/main/kotlin/com/expediagroup/rapid/sdk/core/client/BaseRapidClient.kt
@@ -22,7 +22,7 @@ import com.expediagroup.common.sdk.core.configuration.collector.ConfigurationCol
 import com.expediagroup.common.sdk.core.configuration.provider.ConfigurationProvider
 import com.expediagroup.common.sdk.core.constant.provider.ExceptionMessageProvider
 import com.expediagroup.common.sdk.core.plugin.authentication.strategy.AuthenticationStrategy
-import com.expediagroup.rapid.sdk.core.configuration.RapidClientBuilder
+import com.expediagroup.rapid.sdk.core.configuration.BaseRapidClientBuilder
 import com.expediagroup.rapid.sdk.core.configuration.RapidClientConfiguration
 import com.expediagroup.rapid.sdk.core.configuration.provider.RapidConfigurationProvider
 import com.expediagroup.rapid.sdk.core.model.error.RapidError
@@ -42,7 +42,7 @@ import io.ktor.http.toURI
  * @param httpClientEngine The HTTP client engine to use.
  * @param clientConfiguration The configuration for the client.
  */
-class RapidClient(
+open class BaseRapidClient(
     clientConfiguration: RapidClientConfiguration,
     httpClientEngine: HttpClientEngine = DEFAULT_HTTP_CLIENT_ENGINE
 ) : Client() {
@@ -80,6 +80,6 @@ class RapidClient(
         /** Creates a new RapidClient instance. */
         @JvmStatic
         @Suppress("unused") // Used by the product SDKs.
-        fun builder() = RapidClientBuilder()
+        fun builder() = BaseRapidClientBuilder()
     }
 }

--- a/src/main/kotlin/com/expediagroup/rapid/sdk/core/configuration/BaseRapidClientBuilder.kt
+++ b/src/main/kotlin/com/expediagroup/rapid/sdk/core/configuration/BaseRapidClientBuilder.kt
@@ -19,19 +19,19 @@ import com.expediagroup.common.sdk.core.client.Client
 import com.expediagroup.common.sdk.core.configuration.ClientBuilder
 import com.expediagroup.common.sdk.core.contract.Contract
 import com.expediagroup.common.sdk.core.contract.adhereTo
-import com.expediagroup.rapid.sdk.core.client.RapidClient
+import com.expediagroup.rapid.sdk.core.client.BaseRapidClient
 
 /**
- * A [RapidClient] builder.
+ * A [BaseRapidClient] builder.
  *
  * @property key The API key to use for authentication.
  * @property secret The API secret to use for authentication.
  * @property endpoint The API endpoint to use for requests.
  */
-class RapidClientBuilder : ClientBuilder<RapidClientBuilder>() {
+open class BaseRapidClientBuilder<SELF : BaseRapidClientBuilder<SELF>> : ClientBuilder<SELF>() {
 
-    /** Create a [RapidClient] instance. */
-    override fun build(): RapidClient = Client.create(
+    /** Create a [BaseRapidClient] instance. */
+    override fun build(): BaseRapidClient = Client.create(
         RapidClientConfiguration(
             key = key,
             secret = secret,

--- a/src/main/kotlin/com/expediagroup/rapid/sdk/core/configuration/RapidClientConfiguration.kt
+++ b/src/main/kotlin/com/expediagroup/rapid/sdk/core/configuration/RapidClientConfiguration.kt
@@ -16,10 +16,10 @@
 package com.expediagroup.rapid.sdk.core.configuration
 
 import com.expediagroup.common.sdk.core.configuration.ClientConfiguration
-import com.expediagroup.rapid.sdk.core.client.RapidClient
+import com.expediagroup.rapid.sdk.core.client.BaseRapidClient
 
 /**
- * Configuration for the [RapidClient].
+ * Configuration for the [BaseRapidClient].
  *
  * @property key The API key to use for authentication.
  * @property secret The API secret to use for authentication.

--- a/src/test/kotlin/com/expediagroup/common/sdk/core/test/ClientFactory.kt
+++ b/src/test/kotlin/com/expediagroup/common/sdk/core/test/ClientFactory.kt
@@ -21,7 +21,7 @@ import com.expediagroup.common.sdk.core.test.TestConstants.CLIENT_SECRET_TEST_CR
 import com.expediagroup.openworld.sdk.core.client.OpenWorldClient
 import com.expediagroup.openworld.sdk.core.configuration.OpenWorldClientConfiguration
 import com.expediagroup.openworld.sdk.core.configuration.provider.OpenWorldConfigurationProvider
-import com.expediagroup.rapid.sdk.core.client.RapidClient
+import com.expediagroup.rapid.sdk.core.client.BaseRapidClient
 import com.expediagroup.rapid.sdk.core.configuration.RapidClientConfiguration
 import com.expediagroup.rapid.sdk.core.configuration.provider.RapidConfigurationProvider
 import io.ktor.client.engine.HttpClientEngine
@@ -49,10 +49,10 @@ internal object ClientFactory {
 
     fun createOpenWorldClient(mockEngine: HttpClientEngine, configuration: OpenWorldClientConfiguration): OpenWorldClient = Client.create(configuration, mockEngine)
 
-    fun createRapidClient(mockEngine: HttpClientEngine): RapidClient = Client.create(
+    fun createRapidClient(mockEngine: HttpClientEngine): BaseRapidClient = Client.create(
         rapidConfiguration,
         mockEngine
     )
 
-    fun createRapidClient(): RapidClient = createRapidClient(MockEngineFactory.createEmptyResponseEngine())
+    fun createRapidClient(): BaseRapidClient = createRapidClient(MockEngineFactory.createEmptyResponseEngine())
 }

--- a/src/test/kotlin/com/expediagroup/rapid/sdk/core/configuration/BaseRapidClientBuilderTest.kt
+++ b/src/test/kotlin/com/expediagroup/rapid/sdk/core/configuration/BaseRapidClientBuilderTest.kt
@@ -19,17 +19,17 @@ import com.expediagroup.common.sdk.core.test.TestConstants
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Test
 
-class RapidClientBuilderTest {
+class BaseRapidClientBuilderTest {
 
     @Test
     fun `verify typical behaviour with no configurations`() {
-        assertNotNull(RapidClientBuilder().build().httpClient)
+        assertNotNull(BaseRapidClientBuilder().build().httpClient)
     }
 
     @Test
     fun `verify typical behaviour with configurations`() {
         assertNotNull(
-            RapidClientBuilder()
+            BaseRapidClientBuilder()
                 .key(TestConstants.CLIENT_KEY_TEST_CREDENTIAL)
                 .secret(TestConstants.CLIENT_SECRET_TEST_CREDENTIAL)
                 .endpoint(TestConstants.ANY_URL)

--- a/src/test/kotlin/com/expediagroup/rapid/sdk/core/configuration/BaseRapidClientConfigurationTest.kt
+++ b/src/test/kotlin/com/expediagroup/rapid/sdk/core/configuration/BaseRapidClientConfigurationTest.kt
@@ -19,7 +19,7 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Test
 
-class RapidClientConfigurationTest {
+class BaseRapidClientConfigurationTest {
     @Test
     fun `verify default behaviour`() {
         RapidClientConfiguration().let {


### PR DESCRIPTION
### :pencil: Description
- Rename `RapidClient` to `BaseRapidClient` so we can use `RapidClient` name in the generator.
- Rename `RapidClientBuilder` to `BaseRapidClientBuilder` and open it for the extension.


### :link: Related PRs
- #122 

---
* [x] Code is up-to-date with the `main` branch.
* [x] You've successfully built and run the tests locally.
* [ ] There are new or updated unit tests validating the change.
