### PR TITLE
feat(contract): Add a New Contract: `NO_LEADING_SLASH`

### DIFF
--- a/src/main/kotlin/com/expediagroup/common/sdk/core/contract/Contract.kt
+++ b/src/main/kotlin/com/expediagroup/common/sdk/core/contract/Contract.kt
@@ -22,8 +22,9 @@ internal typealias Operation = (String) -> String
  *
  * @property operation The operation to perform on a string.
  */
-internal enum class Contract(val operation: Operation) {
-    TRAILING_SLASH({ if (it.endsWith("/")) it else "$it/" })
+enum class Contract(val operation: Operation) {
+    TRAILING_SLASH({ if (it.endsWith("/")) it else "$it/" }),
+    NO_LEADING_SLASH({ if (it.startsWith("/")) it.substring(1) else it })
 }
 
 /**
@@ -32,4 +33,4 @@ internal enum class Contract(val operation: Operation) {
  * @param contract the [Contract] to adhere to.
  * @return the [String] adhering to the given [contract].
  */
-internal fun String.adhereTo(contract: Contract): String = contract.operation(this)
+fun String.adhereTo(contract: Contract): String = contract.operation(this)

--- a/src/test/kotlin/com/expediagroup/common/sdk/core/contract/ContractTest.kt
+++ b/src/test/kotlin/com/expediagroup/common/sdk/core/contract/ContractTest.kt
@@ -22,9 +22,13 @@ class ContractTest {
 
     @Test
     fun `Test adhering to a trailing slash`() {
-        val input = "https://api.expediagroup.com"
-        val expected = "https://api.expediagroup.com/"
-        val actual: String = input.adhereTo(Contract.TRAILING_SLASH)
-        assertEquals(expected, actual)
+        assertEquals("https://api.expediagroup.com/", "https://api.expediagroup.com/".adhereTo(Contract.TRAILING_SLASH))
+        assertEquals("https://api.expediagroup.com/", "https://api.expediagroup.com".adhereTo(Contract.TRAILING_SLASH))
+    }
+
+    @Test
+    fun `Test adhering to No leading slash`() {
+        assertEquals("api.expediagroup.com", "/api.expediagroup.com".adhereTo(Contract.NO_LEADING_SLASH))
+        assertEquals("api.expediagroup.com", "api.expediagroup.com".adhereTo(Contract.NO_LEADING_SLASH))
     }
 }


### PR DESCRIPTION
- Add a New Contract: `NO_LEADING_SLASH`
- Externalize `Contract` and `adhereTo` to be available rto use in the generators.


---
* [x] Code is up-to-date with the `main` branch.
* [x] You've successfully built and run the tests locally.
* [x] There are new or updated unit tests validating the change.
