### PR TITLE
fix(authentication): Assign New Token to New Requests

### DIFF
--- a/src/main/kotlin/com/expediagroup/openworld/sdk/core/plugin/authentication/AuthenticationHookFactory.kt
+++ b/src/main/kotlin/com/expediagroup/openworld/sdk/core/plugin/authentication/AuthenticationHookFactory.kt
@@ -55,18 +55,14 @@ private class AuthenticationHookBuilder(private val client: Client) : HookBuilde
                         }
                     }
                 }
-                waitForTokenRenewal()
-                assignNewToken(request)
+                while (lock.value) delay(AUTHORIZATION_REQUEST_LOCK_DELAY)
+                assignLatestToken(request)
             }
             execute(request)
         }
     }
 
-    private fun assignNewToken(request: HttpRequestBuilder) {
+    private fun assignLatestToken(request: HttpRequestBuilder) {
         request.headers[HeaderKey.AUTHORIZATION] = authenticationStrategy.getAuthorizationHeader()
-    }
-
-    private suspend fun waitForTokenRenewal() {
-        while (lock.value) delay(AUTHORIZATION_REQUEST_LOCK_DELAY)
     }
 }

--- a/src/main/kotlin/com/expediagroup/openworld/sdk/core/plugin/authentication/AuthenticationHookFactory.kt
+++ b/src/main/kotlin/com/expediagroup/openworld/sdk/core/plugin/authentication/AuthenticationHookFactory.kt
@@ -44,7 +44,7 @@ private class AuthenticationHookBuilder(private val client: Client) : HookBuilde
         val httpClient = client.httpClient
 
         httpClient.plugin(HttpSend).intercept { request ->
-            if (authenticationStrategy.isNotIdentityRequest(request)) {
+            if (!authenticationStrategy.isIdentityRequest(request)) {
                 if (authenticationStrategy.isTokenAboutToExpire()) {
                     log.info(TOKEN_EXPIRED)
                     if (!lock.getAndSet(true)) {

--- a/src/main/kotlin/com/expediagroup/openworld/sdk/core/plugin/authentication/strategy/AuthenticationStrategy.kt
+++ b/src/main/kotlin/com/expediagroup/openworld/sdk/core/plugin/authentication/strategy/AuthenticationStrategy.kt
@@ -29,7 +29,7 @@ internal interface AuthenticationStrategy {
 
     fun renewToken()
 
-    fun isNotIdentityRequest(request: HttpRequestBuilder): Boolean
+    fun isIdentityRequest(request: HttpRequestBuilder): Boolean
 
     fun getAuthorizationHeader(): String
 

--- a/src/main/kotlin/com/expediagroup/openworld/sdk/core/plugin/authentication/strategy/OpenWorldAuthenticationStrategy.kt
+++ b/src/main/kotlin/com/expediagroup/openworld/sdk/core/plugin/authentication/strategy/OpenWorldAuthenticationStrategy.kt
@@ -52,7 +52,7 @@ internal class OpenWorldAuthenticationStrategy(
     override fun loadAuth(auth: Auth) {
         auth.bearer {
             sendWithoutRequest { request ->
-                isNotIdentityRequest(request)
+                isIdentityRequest(request)
             }
         }
     }
@@ -100,7 +100,7 @@ internal class OpenWorldAuthenticationStrategy(
         )
     }
 
-    override fun isNotIdentityRequest(request: HttpRequestBuilder): Boolean = request.url.buildString() != configs.authUrl
+    override fun isIdentityRequest(request: HttpRequestBuilder): Boolean = request.url.buildString() == configs.authUrl
 
     override fun getAuthorizationHeader() = "${Authentication.BEARER} ${getTokens().accessToken}"
 

--- a/src/main/kotlin/com/expediagroup/openworld/sdk/core/plugin/authentication/strategy/OpenWorldAuthenticationStrategy.kt
+++ b/src/main/kotlin/com/expediagroup/openworld/sdk/core/plugin/authentication/strategy/OpenWorldAuthenticationStrategy.kt
@@ -48,14 +48,9 @@ internal class OpenWorldAuthenticationStrategy(
 ) : AuthenticationStrategy {
     private val log = OpenWorldLoggerFactory.getLogger(javaClass)
     private var bearerTokenStorage = BearerTokensInfo.emptyBearerTokenInfo
-    private val loadTokensBlock: () -> BearerTokens = {
-        getTokens()
-    }
 
     override fun loadAuth(auth: Auth) {
         auth.bearer {
-            loadTokens(loadTokensBlock)
-
             sendWithoutRequest { request ->
                 isNotIdentityRequest(request)
             }

--- a/src/main/kotlin/com/expediagroup/openworld/sdk/core/plugin/authentication/strategy/RapidAuthenticationStrategy.kt
+++ b/src/main/kotlin/com/expediagroup/openworld/sdk/core/plugin/authentication/strategy/RapidAuthenticationStrategy.kt
@@ -35,7 +35,7 @@ internal class RapidAuthenticationStrategy(private val configs: AuthenticationCo
         signature = calculateSignature(credentials.key, credentials.secret, Instant.now().epochSecond)
     }
 
-    override fun isNotIdentityRequest(request: HttpRequestBuilder) = true
+    override fun isIdentityRequest(request: HttpRequestBuilder) = false
 
     override fun getAuthorizationHeader() = createAuthorizationHeader(signature)
 

--- a/src/test/kotlin/com/expediagroup/openworld/sdk/core/authentication/strategy/OpenWorldAuthenticationStrategyTest.kt
+++ b/src/test/kotlin/com/expediagroup/openworld/sdk/core/authentication/strategy/OpenWorldAuthenticationStrategyTest.kt
@@ -20,6 +20,7 @@ import com.expediagroup.openworld.sdk.core.configuration.Credentials
 import com.expediagroup.openworld.sdk.core.configuration.OpenWorldClientConfiguration
 import com.expediagroup.openworld.sdk.core.configuration.provider.OpenWorldConfigurationProvider
 import com.expediagroup.openworld.sdk.core.constant.Authentication.BEARER
+import com.expediagroup.openworld.sdk.core.constant.Constant.SUCCESSFUL_STATUS_CODES_RANGE
 import com.expediagroup.openworld.sdk.core.constant.ExceptionMessage
 import com.expediagroup.openworld.sdk.core.constant.HeaderKey
 import com.expediagroup.openworld.sdk.core.model.exception.service.OpenWorldAuthException
@@ -40,6 +41,7 @@ import io.ktor.client.HttpClientConfig
 import io.ktor.client.request.get
 import io.ktor.client.request.request
 import io.ktor.client.request.url
+import io.ktor.client.statement.HttpResponse
 import io.ktor.client.statement.request
 import io.ktor.http.HttpMethod
 import io.ktor.http.HttpStatusCode
@@ -57,6 +59,10 @@ import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ArgumentsSource
 import org.junit.jupiter.params.provider.ValueSource
+import java.util.concurrent.Callable
+import java.util.concurrent.ExecutorService
+import java.util.concurrent.Executors
+import java.util.concurrent.Future
 
 internal class OpenWorldAuthenticationStrategyTest : AuthenticationPluginTest() {
 
@@ -123,6 +129,32 @@ internal class OpenWorldAuthenticationStrategyTest : AuthenticationPluginTest() 
                 launch(Dispatchers.IO) { httpClient.get(ANY_URL) },
                 launch(Dispatchers.IO) { httpClient.get(ANY_URL) }
             ).joinAll()
+
+            verify(exactly = 1) {
+                authentication.renewToken()
+            }
+        }
+    }
+
+    @Test
+    fun `make parallel should run the single refresh token only and authorize all`() {
+        runBlocking {
+            val client = ClientFactory.createOpenWorldClient()
+            val httpClient = client.httpClient
+            val authentication = client.getAuthenticationStrategy()
+            mockkObject(authentication)
+
+            val numberOfThreads = 8
+            val threadPool: ExecutorService = Executors.newFixedThreadPool(numberOfThreads)
+            val futures: MutableList<Future<HttpResponse>> = mutableListOf()
+            repeat(numberOfThreads + 5) {
+                futures.add(threadPool.submit(Callable { runBlocking { httpClient.get(ANY_URL) } }))
+            }
+
+            val failedRequests: List<HttpResponse> = futures.map { it.get() }.filter {
+                it.status.value !in SUCCESSFUL_STATUS_CODES_RANGE
+            }
+            assertThat(failedRequests).isEmpty()
 
             verify(exactly = 1) {
                 authentication.renewToken()

--- a/src/test/kotlin/com/expediagroup/openworld/sdk/core/authentication/strategy/OpenWorldAuthenticationStrategyTest.kt
+++ b/src/test/kotlin/com/expediagroup/openworld/sdk/core/authentication/strategy/OpenWorldAuthenticationStrategyTest.kt
@@ -137,7 +137,7 @@ internal class OpenWorldAuthenticationStrategyTest : AuthenticationPluginTest() 
     }
 
     @Test
-    fun `make parallel should run the single refresh token only and authorize all`() {
+    fun `given requests constructed during token renewal then get assigned the new token`() {
         runBlocking {
             val client = ClientFactory.createOpenWorldClient()
             val httpClient = client.httpClient


### PR DESCRIPTION
* [x] Code is up-to-date with the `main` branch.
* [x] You've successfully built and run the tests locally.
* [x] There are new or updated unit tests validating the change.

### :pencil: Description
- Assign new token to new requests constructed at token-renewal time

Description of issue: Given a request constructed during token renewal, when the token gets renewed before the request is fully constructed, the request won't get the new token.

### :link: Related Issues
- N/A
