### PR TITLE
chore(generation): Fix Hibernate Validator Dependency

### DIFF
--- a/generator/openapi/src/main/resources/templates/openworld-sdk/pom.mustache
+++ b/generator/openapi/src/main/resources/templates/openworld-sdk/pom.mustache
@@ -84,7 +84,7 @@
         </dependency>
 
         <dependency>
-            <groupId>org.hibernate</groupId>
+            <groupId>org.hibernate.validator</groupId>
             <artifactId>hibernate-validator</artifactId>
             <version>7.0.5.Final</version>
         </dependency>


### PR DESCRIPTION
* [x] Code is up-to-date with the `main` branch.
* [x] You've successfully built and run the tests locally.
* [ ] There are new or updated unit tests validating the change.

### :pencil: Description
- Fix Hibernate Validator dependency to remove warning about relocation
`[WARNING] The artifact org.hibernate:hibernate-validator:jar:7.0.5.Final has been relocated to org.hibernate.validator:hibernate-validator:jar:7.0.5.Final`

### :link: Related Issues
N/A
