### PR TITLE
fix(generation): Define optional fields in builders as nullable

### DIFF
--- a/generator/openapi/src/main/resources/templates/expediagroup-sdk/data_class.mustache
+++ b/generator/openapi/src/main/resources/templates/expediagroup-sdk/data_class.mustache
@@ -62,7 +62,7 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo
     ) {
     {{#allVars}}
         {{#eliminateDiscriminators}}
-        fun {{{name}}}({{{name}}}: {{#isEnum}}{{^isArray}}{{^isInherited}}{{classname}}.{{{nameInCamelCase}}}{{/isInherited}}{{/isArray}}{{^isArray}}{{#isInherited}}{{{parent}}}.{{{nameInCamelCase}}}{{/isInherited}}{{/isArray}}{{/isEnum}}{{^isEnum}}{{{dataType}}}{{/isEnum}}) = apply { this.{{{name}}} = {{{name}}} }
+        fun {{{name}}}({{{name}}}: {{#isEnum}}{{^isArray}}{{^isInherited}}{{classname}}.{{{nameInCamelCase}}}{{/isInherited}}{{/isArray}}{{^isArray}}{{#isInherited}}{{{parent}}}.{{{nameInCamelCase}}}{{/isInherited}}{{/isArray}}{{/isEnum}}{{^isEnum}}{{{dataType}}}{{/isEnum}}{{^required}}?{{/required}}) = apply { this.{{{name}}} = {{{name}}} }
         {{/eliminateDiscriminators}}
     {{/allVars}}
 


### PR DESCRIPTION
* [x] Code is up-to-date with the `main` branch.
* [x] You've successfully built and run the tests locally.
* [ ] There are new or updated unit tests validating the change.

### :pencil: Description
- Define optional fields in builders as nullable

### :link: Related Issues
N/A
