### PR TITLE
fix: remove token-expired log from rapid authentication

### DIFF
--- a/core/src/main/kotlin/com/expediagroup/sdk/core/plugin/authentication/AuthenticationHookFactory.kt
+++ b/core/src/main/kotlin/com/expediagroup/sdk/core/plugin/authentication/AuthenticationHookFactory.kt
@@ -18,7 +18,6 @@ package com.expediagroup.sdk.core.plugin.authentication
 import com.expediagroup.sdk.core.client.Client
 import com.expediagroup.sdk.core.constant.Authentication.AUTHORIZATION_REQUEST_LOCK_DELAY
 import com.expediagroup.sdk.core.constant.HeaderKey
-import com.expediagroup.sdk.core.constant.LoggingMessage.TOKEN_EXPIRED
 import com.expediagroup.sdk.core.plugin.Hook
 import com.expediagroup.sdk.core.plugin.HookBuilder
 import com.expediagroup.sdk.core.plugin.HookFactory
@@ -49,7 +48,6 @@ private class AuthenticationHookBuilder(private val client: Client) : HookBuilde
         httpClient.plugin(HttpSend).intercept { request ->
             if (!authenticationStrategy.isIdentityRequest(request)) {
                 if (authenticationStrategy.isTokenAboutToExpire()) {
-                    log.info(TOKEN_EXPIRED)
                     if (!lock.getAndSet(true)) {
                         try {
                             authenticationStrategy.renewToken()

--- a/core/src/main/kotlin/com/expediagroup/sdk/core/plugin/authentication/strategy/ExpediaGroupAuthenticationStrategy.kt
+++ b/core/src/main/kotlin/com/expediagroup/sdk/core/plugin/authentication/strategy/ExpediaGroupAuthenticationStrategy.kt
@@ -105,7 +105,6 @@ internal class ExpediaGroupAuthenticationStrategy(
         )
     }
 
-
     override fun isIdentityRequest(request: HttpRequestBuilder): Boolean = request.url.clone().apply { encodedParameters = ParametersBuilder() }.buildString() == configs.authUrl
 
     override fun getAuthorizationHeader() = "${Authentication.BEARER} ${getTokens().accessToken}"

--- a/core/src/main/kotlin/com/expediagroup/sdk/core/plugin/authentication/strategy/ExpediaGroupAuthenticationStrategy.kt
+++ b/core/src/main/kotlin/com/expediagroup/sdk/core/plugin/authentication/strategy/ExpediaGroupAuthenticationStrategy.kt
@@ -59,7 +59,7 @@ internal class ExpediaGroupAuthenticationStrategy(
         }
     }
 
-    override fun isTokenAboutToExpire(): Boolean = bearerTokenStorage.isAboutToExpire()
+    override fun isTokenAboutToExpire(): Boolean = bearerTokenStorage.isAboutToExpire().also { if (it) log.info(LoggingMessage.TOKEN_EXPIRED) }
 
     override fun renewToken() {
         val httpClient = httpClientProvider()
@@ -128,7 +128,6 @@ internal class ExpediaGroupAuthenticationStrategy(
         }
     }
 
-    //
     internal data class TokenResponse(
         val accessToken: String,
         val expiresIn: Int

--- a/core/src/main/kotlin/com/expediagroup/sdk/core/plugin/authentication/strategy/ExpediaGroupAuthenticationStrategy.kt
+++ b/core/src/main/kotlin/com/expediagroup/sdk/core/plugin/authentication/strategy/ExpediaGroupAuthenticationStrategy.kt
@@ -105,6 +105,7 @@ internal class ExpediaGroupAuthenticationStrategy(
         )
     }
 
+
     override fun isIdentityRequest(request: HttpRequestBuilder): Boolean = request.url.clone().apply { encodedParameters = ParametersBuilder() }.buildString() == configs.authUrl
 
     override fun getAuthorizationHeader() = "${Authentication.BEARER} ${getTokens().accessToken}"


### PR DESCRIPTION
* [x] Code is up-to-date with the `main` branch.
* [x] You've successfully built and run the tests locally.
* [ ] There are new or updated unit tests validating the change.

### :pencil: Description
- Remove "token expired" log from Rapid authentication

### :link: Related Issues
N/A
