### PR TITLE
fix: enhance generated javadocs

### DIFF
--- a/generator/openapi/src/main/kotlin/com/expediagroup/sdk/generators/openapi/DataTypes.kt
+++ b/generator/openapi/src/main/kotlin/com/expediagroup/sdk/generators/openapi/DataTypes.kt
@@ -1,0 +1,24 @@
+/*
+ * Copyright (C) 2022 Expedia, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.expediagroup.sdk.generators.openapi
+
+import com.samskivert.mustache.Template
+import org.openapitools.codegen.CodegenOperation
+
+internal fun collectDataTypes(fragment: Template.Fragment): Set<String> {
+    val operation: CodegenOperation = fragment.context() as CodegenOperation
+    return operation.responses.filter { !it.is2xx }.map { it.dataType }.toSet()
+}

--- a/generator/openapi/src/main/kotlin/com/expediagroup/sdk/generators/openapi/MustacheHelpers.kt
+++ b/generator/openapi/src/main/kotlin/com/expediagroup/sdk/generators/openapi/MustacheHelpers.kt
@@ -17,7 +17,6 @@ package com.expediagroup.sdk.generators.openapi
 
 import com.samskivert.mustache.Mustache
 import org.openapitools.codegen.CodegenModel
-import org.openapitools.codegen.CodegenOperation
 import org.openapitools.codegen.CodegenProperty
 import org.openapitools.codegen.model.OperationsMap
 
@@ -61,13 +60,7 @@ val mustacheHelpers = mapOf(
     },
     "throwsExceptions" to {
         Mustache.Lambda { fragment, writer ->
-            val dataTypes: MutableSet<String> = mutableSetOf()
-            val operation: CodegenOperation = fragment.context() as CodegenOperation
-            operation.responses.forEach { response ->
-                response.takeIf { !it.is2xx && !dataTypes.contains(it.dataType) }?.dataType?.also {
-                    dataTypes.add(it)
-                }
-            }
+            val dataTypes: Set<String> = collectDataTypes(fragment)
             val stringBuilder = StringBuilder()
             dataTypes.forEachIndexed { index, dataType ->
                 if (index > 0) stringBuilder.append(" ".repeat(5))
@@ -79,13 +72,7 @@ val mustacheHelpers = mapOf(
     },
     "throwsExceptionsClasses" to {
         Mustache.Lambda { fragment, writer ->
-            val dataTypes: MutableSet<String> = mutableSetOf()
-            val operation: CodegenOperation = fragment.context() as CodegenOperation
-            operation.responses.forEach { response ->
-                response.takeIf { !it.is2xx && !dataTypes.contains(it.dataType) }?.dataType?.also {
-                    dataTypes.add(it)
-                }
-            }
+            val dataTypes: Set<String> = collectDataTypes(fragment)
             val stringBuilder = StringBuilder()
             dataTypes.forEachIndexed { index, dataType ->
                 if (index > 0) stringBuilder.append(" ".repeat(8))

--- a/generator/openapi/src/main/kotlin/com/expediagroup/sdk/generators/openapi/MustacheHelpers.kt
+++ b/generator/openapi/src/main/kotlin/com/expediagroup/sdk/generators/openapi/MustacheHelpers.kt
@@ -17,6 +17,7 @@ package com.expediagroup.sdk.generators.openapi
 
 import com.samskivert.mustache.Mustache
 import org.openapitools.codegen.CodegenModel
+import org.openapitools.codegen.CodegenOperation
 import org.openapitools.codegen.CodegenProperty
 import org.openapitools.codegen.model.OperationsMap
 
@@ -56,6 +57,42 @@ val mustacheHelpers = mapOf(
                     }
                 }
             }
+        }
+    },
+    "throwsExceptions" to {
+        Mustache.Lambda { fragment, writer ->
+            val dataTypes: MutableSet<String> = mutableSetOf()
+            val operation: CodegenOperation = fragment.context() as CodegenOperation
+            operation.responses.forEach { response ->
+                response.takeIf { !it.is2xx && !dataTypes.contains(it.dataType) }?.dataType?.also {
+                    dataTypes.add(it)
+                }
+            }
+            val stringBuilder = StringBuilder()
+            dataTypes.forEachIndexed { index, dataType ->
+                if (index > 0) stringBuilder.append(" ".repeat(5))
+                stringBuilder.append("* @throws ExpediaGroupApi${dataType}Exception")
+                if (index < dataTypes.size - 1) stringBuilder.append("\n")
+            }
+            writer.write(stringBuilder.toString())
+        }
+    },
+    "throwsExceptionsClasses" to {
+        Mustache.Lambda { fragment, writer ->
+            val dataTypes: MutableSet<String> = mutableSetOf()
+            val operation: CodegenOperation = fragment.context() as CodegenOperation
+            operation.responses.forEach { response ->
+                response.takeIf { !it.is2xx && !dataTypes.contains(it.dataType) }?.dataType?.also {
+                    dataTypes.add(it)
+                }
+            }
+            val stringBuilder = StringBuilder()
+            dataTypes.forEachIndexed { index, dataType ->
+                if (index > 0) stringBuilder.append(" ".repeat(8))
+                stringBuilder.append("ExpediaGroupApi${dataType}Exception::class")
+                if (index < dataTypes.size - 1) stringBuilder.append(",\n")
+            }
+            writer.write(stringBuilder.toString())
         }
     }
 )

--- a/generator/openapi/src/main/resources/templates/expediagroup-sdk/client/client.mustache
+++ b/generator/openapi/src/main/resources/templates/expediagroup-sdk/client/client.mustache
@@ -77,20 +77,16 @@ import {{import}}
     {{^isKotlin}}
 
     /**
-    * {{summary}}
-    * {{notes}}
+     * {{{summary}}}
+     * {{{notes}}}
     {{#queryParams}} * @param {{{paramName}}} {{description}}{{^required}} (optional{{#defaultValue}}, default to {{{.}}}{{/defaultValue}}){{/required}}{{#required}}{{#defaultValue}} (default to {{{.}}}){{/defaultValue}}{{/required}}
     {{/queryParams}}{{#bodyParams}} * @param {{{paramName}}} {{description}}{{^required}} (optional{{#defaultValue}}, default to {{{.}}}{{/defaultValue}}){{/required}}{{#required}}{{#defaultValue}} (default to {{{.}}}){{/defaultValue}}{{/required}}
     {{/bodyParams}} {{#formParams}} * @param {{{paramName}}} {{description}}{{^required}} (optional{{#defaultValue}}, default to {{{.}}}{{/defaultValue}}){{/required}}{{#required}}{{#defaultValue}} (default to {{{.}}}){{/defaultValue}}{{/required}}
-    {{/formParams}}{{#responses}}{{^is2xx}}* @throws ExpediaGroupApi{{{dataType}}}Exception{{/is2xx}}
-    {{/responses}}* @return {{{returnType}}}{{^returnType}}Nothing{{/returnType}}
-    */
+    {{/formParams}}{{#throwsExceptions}}{{/throwsExceptions}}
+     * @return {{{returnType}}}{{^returnType}}Nothing{{/returnType}}
+     */
     @Throws(
-    {{#responses}}
-        {{^is2xx}}
-            ExpediaGroupApi{{{dataType}}}Exception::class{{^-last}},{{/-last}}
-        {{/is2xx}}
-    {{/responses}}
+        {{#throwsExceptionsClasses}}{{/throwsExceptionsClasses}}
     )
     @JvmOverloads
     fun {{operationId}}({{>client/apiParamsDecleration}}) : {{{returnType}}}{{^returnType}}Nothing{{/returnType}} {
@@ -98,20 +94,16 @@ import {{import}}
     }
 
     /**
-    * {{summary}}
-    * {{notes}}
+     * {{{summary}}}
+     * {{{notes}}}
     {{#queryParams}} * @param {{{paramName}}} {{description}}{{^required}} (optional{{#defaultValue}}, default to {{{.}}}{{/defaultValue}}){{/required}}{{#required}}{{#defaultValue}} (default to {{{.}}}){{/defaultValue}}{{/required}}
     {{/queryParams}}{{#bodyParams}} * @param {{{paramName}}} {{description}}{{^required}} (optional{{#defaultValue}}, default to {{{.}}}{{/defaultValue}}){{/required}}{{#required}}{{#defaultValue}} (default to {{{.}}}){{/defaultValue}}{{/required}}
     {{/bodyParams}} {{#formParams}} * @param {{{paramName}}} {{description}}{{^required}} (optional{{#defaultValue}}, default to {{{.}}}{{/defaultValue}}){{/required}}{{#required}}{{#defaultValue}} (default to {{{.}}}){{/defaultValue}}{{/required}}
-    {{/formParams}}{{#responses}}{{^is2xx}}* @throws ExpediaGroupApi{{{dataType}}}Exception{{/is2xx}}
-    {{/responses}}* @return a [Response] object with a body of type {{{returnType}}}{{^returnType}}Nothing{{/returnType}}
-    */
+    {{/formParams}}{{#throwsExceptions}}{{/throwsExceptions}}
+     * @return a [Response] object with a body of type {{{returnType}}}{{^returnType}}Nothing{{/returnType}}
+     */
     @Throws(
-    {{#responses}}
-        {{^is2xx}}
-            ExpediaGroupApi{{{dataType}}}Exception::class{{^-last}},{{/-last}}
-        {{/is2xx}}
-    {{/responses}}
+        {{#throwsExceptionsClasses}}{{/throwsExceptionsClasses}}
     )
     @JvmOverloads
     fun {{operationId}}WithResponse({{>client/apiParamsDecleration}}) : {{#returnType}}Response<{{{returnType}}}>{{/returnType}}{{^returnType}}Response<Nothing>{{/returnType}} {

--- a/generator/openapi/src/main/resources/templates/expediagroup-sdk/client/client.mustache
+++ b/generator/openapi/src/main/resources/templates/expediagroup-sdk/client/client.mustache
@@ -79,10 +79,10 @@ import {{import}}
     /**
      * {{{summary}}}
      * {{{notes}}}
-    {{#queryParams}} * @param {{{paramName}}} {{description}}{{^required}} (optional{{#defaultValue}}, default to {{{.}}}{{/defaultValue}}){{/required}}{{#required}}{{#defaultValue}} (default to {{{.}}}){{/defaultValue}}{{/required}}
-    {{/queryParams}}{{#bodyParams}} * @param {{{paramName}}} {{description}}{{^required}} (optional{{#defaultValue}}, default to {{{.}}}{{/defaultValue}}){{/required}}{{#required}}{{#defaultValue}} (default to {{{.}}}){{/defaultValue}}{{/required}}
-    {{/bodyParams}} {{#formParams}} * @param {{{paramName}}} {{description}}{{^required}} (optional{{#defaultValue}}, default to {{{.}}}{{/defaultValue}}){{/required}}{{#required}}{{#defaultValue}} (default to {{{.}}}){{/defaultValue}}{{/required}}
-    {{/formParams}}{{#throwsExceptions}}{{/throwsExceptions}}
+{{#allParams}}     * @param {{{paramName}}} {{{description}}}{{^required}} (optional{{#defaultValue}}, defaults to {{{.}}}{{/defaultValue}}){{/required}}{{#required}}{{#defaultValue}} (defaults to {{{.}}}){{/defaultValue}}{{/required}}
+{{/allParams}}
+     * @param transactionId The transaction id for the request (optional, defaults to a new UUID)
+     {{#throwsExceptions}}{{/throwsExceptions}}
      * @return {{{returnType}}}{{^returnType}}Nothing{{/returnType}}
      */
     @Throws(
@@ -96,10 +96,10 @@ import {{import}}
     /**
      * {{{summary}}}
      * {{{notes}}}
-    {{#queryParams}} * @param {{{paramName}}} {{description}}{{^required}} (optional{{#defaultValue}}, default to {{{.}}}{{/defaultValue}}){{/required}}{{#required}}{{#defaultValue}} (default to {{{.}}}){{/defaultValue}}{{/required}}
-    {{/queryParams}}{{#bodyParams}} * @param {{{paramName}}} {{description}}{{^required}} (optional{{#defaultValue}}, default to {{{.}}}{{/defaultValue}}){{/required}}{{#required}}{{#defaultValue}} (default to {{{.}}}){{/defaultValue}}{{/required}}
-    {{/bodyParams}} {{#formParams}} * @param {{{paramName}}} {{description}}{{^required}} (optional{{#defaultValue}}, default to {{{.}}}{{/defaultValue}}){{/required}}{{#required}}{{#defaultValue}} (default to {{{.}}}){{/defaultValue}}{{/required}}
-    {{/formParams}}{{#throwsExceptions}}{{/throwsExceptions}}
+{{#allParams}}     * @param {{{paramName}}} {{{description}}}{{^required}} (optional{{#defaultValue}}, defaults to {{{.}}}{{/defaultValue}}){{/required}}{{#required}}{{#defaultValue}} (defaults to {{{.}}}){{/defaultValue}}{{/required}}
+{{/allParams}}
+     * @param transactionId The transaction id for the request (optional, defaults to a new UUID)
+     {{#throwsExceptions}}{{/throwsExceptions}}
      * @return a [Response] object with a body of type {{{returnType}}}{{^returnType}}Nothing{{/returnType}}
      */
     @Throws(


### PR DESCRIPTION
* [x] Code is up-to-date with the `main` branch.
* [x] You've successfully built and run the tests locally.
* [x] There are new or updated unit tests validating the change.

### :pencil: Description
- Fix generated javadocs

### :link: Related Issues
N/A

### Sample Output
#### Rapid
```java
/**
 * Property Guest Reviews
 * <i>Note: Property Guest Reviews are only available if your account is configured for access and all launch requirements have been followed. Please find the launch requirements here [https://support.expediapartnersolutions.com/hc/en-us/articles/360008646799](https://support.expediapartnersolutions.com/hc/en-us/articles/360008646799) and contact your Account Manager for more details.</i>  The response is an individual Guest Reviews object containing multiple guest reviews for the requested active property.  To ensure you always show the latest guest reviews, this call should be made whenever a customer looks at the details for a specific property. 
 * @param propertyId Expedia Property ID.<br> 
 * @param language Desired language for the response as a subset of BCP47 format that only uses hyphenated pairs of two-digit language and country codes. Use only ISO 639-1 alpha-2 language codes and ISO 3166-1 alpha-2 country codes. See [https://www.w3.org/International/articles/language-tags/](https://www.w3.org/International/articles/language-tags/)  Language Options: [https://developers.expediagroup.com/docs/rapid/resources/reference/language-options](https://developers.expediagroup.com/docs/rapid/resources/reference/language-options) 
 * @param customerSessionId Insert your own unique value for each user session, beginning with the first API call. Continue to pass the same value for each subsequent API call during the user's session, using a new value for every new customer session.<br> Including this value greatly eases EPS's internal debugging process for issues with partner requests, as it explicitly links together request paths for individual user's session.  (optional)
 * @param billingTerms This parameter is to specify the terms of how a resulting booking should be billed. If this field is needed, the value for this will be provided to you separately.  (optional)
 * @param paymentTerms This parameter is to specify what terms should be used when being paid for a resulting booking. If this field is needed, the value for this will be provided to you separately.  (optional)
 * @param partnerPointOfSale This parameter is to specify what point of sale is being used to shop and book. If this field is needed, the value for this will be provided to you separately.  (optional)
 * @param platformName This parameter is to specify what platform is being used to shop and book. If this field is needed, the value for this will be provided to you separately.  (optional)
 * @param transactionId The transaction id for the request (optional, defaults to a new UUID)
 * @throws ExpediaGroupApiErrorException
 * @return GuestReviews
 */
@Throws(
    ExpediaGroupApiErrorException::class
)
@JvmOverloads
fun getPropertyGuestReviews(propertyId: kotlin.String, language: kotlin.String, customerSessionId: kotlin.String? = null, billingTerms: kotlin.String? = null, paymentTerms: kotlin.String? = null, partnerPointOfSale: kotlin.String? = null, platformName: kotlin.String? = null, transactionId: UUID = UUID.randomUUID()) : GuestReviews {
    return getPropertyGuestReviewsWithResponse(propertyId, language, customerSessionId, billingTerms, paymentTerms, partnerPointOfSale, platformName, transactionId).body
}
```

#### Fraud Prevention
```java
/**
 * Run fraud screening for one transaction
 * The Order Purchase API gives a Fraud recommendation for a transaction. A recommendation can be Accept, Reject, or Review. A transaction is marked as Review whenever there are insufficient signals to recommend Accept or Reject. These incidents are manually reviewed, and a corrected recommendation is made asynchronously. 
 * @param orderPurchaseScreenRequest 
 * @param transactionId The transaction id for the request (optional, defaults to a new UUID)
 * @throws ExpediaGroupApiBadRequestErrorException
 * @throws ExpediaGroupApiUnauthorizedErrorException
 * @throws ExpediaGroupApiForbiddenErrorException
 * @throws ExpediaGroupApiNotFoundErrorException
 * @throws ExpediaGroupApiTooManyRequestsErrorException
 * @throws ExpediaGroupApiInternalServerErrorException
 * @throws ExpediaGroupApiBadGatewayErrorException
 * @throws ExpediaGroupApiRetryableOrderPurchaseScreenFailureException
 * @throws ExpediaGroupApiGatewayTimeoutErrorException
 * @return OrderPurchaseScreenResponse
 */
@Throws(
    ExpediaGroupApiBadRequestErrorException::class,
    ExpediaGroupApiUnauthorizedErrorException::class,
    ExpediaGroupApiForbiddenErrorException::class,
    ExpediaGroupApiNotFoundErrorException::class,
    ExpediaGroupApiTooManyRequestsErrorException::class,
    ExpediaGroupApiInternalServerErrorException::class,
    ExpediaGroupApiBadGatewayErrorException::class,
    ExpediaGroupApiRetryableOrderPurchaseScreenFailureException::class,
    ExpediaGroupApiGatewayTimeoutErrorException::class
)
@JvmOverloads
fun screenOrder(orderPurchaseScreenRequest: OrderPurchaseScreenRequest, transactionId: UUID = UUID.randomUUID()) : OrderPurchaseScreenResponse {
    return screenOrderWithResponse(orderPurchaseScreenRequest, transactionId).body
}
```