### PR TITLE
feat: log request and response bodies independently from ktor

### DIFF
--- a/core/src/main/kotlin/com/expediagroup/sdk/core/constant/HeaderKey.kt
+++ b/core/src/main/kotlin/com/expediagroup/sdk/core/constant/HeaderKey.kt
@@ -23,4 +23,6 @@ internal object HeaderKey {
     const val PAGINATION_TOTAL_RESULTS = "pagination-total-results"
 
     const val LINK = "link"
+
+    const val TRANSACTION_ID = "transaction-id"
 }

--- a/core/src/main/kotlin/com/expediagroup/sdk/core/constant/LoggerName.kt
+++ b/core/src/main/kotlin/com/expediagroup/sdk/core/constant/LoggerName.kt
@@ -16,5 +16,6 @@
 package com.expediagroup.sdk.core.constant
 
 internal object LoggerName {
+    const val REQUEST_BODY_LOGGER: String = "RequestBodyLogger"
     const val RESPONSE_BODY_LOGGER: String = "ResponseBodyLogger"
 }

--- a/core/src/main/kotlin/com/expediagroup/sdk/core/constant/provider/LoggingMessageProvider.kt
+++ b/core/src/main/kotlin/com/expediagroup/sdk/core/constant/provider/LoggingMessageProvider.kt
@@ -27,5 +27,15 @@ internal object LoggingMessageProvider {
         providerName: String
     ) = "Successfully loaded [$property] from [$providerName]"
 
-    fun getResponseBodyMessage(body: String) = "Response Body: $body"
+    fun getResponseBodyMessage(
+        body: String,
+        transactionId: String?
+    ) = "Response Body${getTransactionIdMessage(transactionId)}: $body"
+
+    fun getRequestBodyMessage(
+        body: String,
+        transactionId: String?
+    ) = "Request Body${getTransactionIdMessage(transactionId)}: $body"
+
+    private fun getTransactionIdMessage(transactionId: String?) = if (transactionId != null) " [transactionId=$transactionId]" else ""
 }

--- a/core/src/main/kotlin/com/expediagroup/sdk/core/plugin/logging/LoggingConfiguration.kt
+++ b/core/src/main/kotlin/com/expediagroup/sdk/core/plugin/logging/LoggingConfiguration.kt
@@ -26,7 +26,7 @@ internal data class LoggingConfiguration(
     override val httpClientConfiguration: HttpClientConfig<out HttpClientEngineConfig>,
     val maskedLoggingHeaders: Set<String>,
     val maskedLoggingBodyFields: Set<String>,
-    val level: LogLevel = LogLevel.ALL,
+    val level: LogLevel = LogLevel.HEADERS,
     val getLogger: (client: Client) -> Logger = createCustomLogger
 ) : KtorPluginConfiguration(httpClientConfiguration) {
     companion object {
@@ -41,7 +41,7 @@ internal data class LoggingConfiguration(
 private val createCustomLogger: (client: Client) -> Logger
     get() = {
         object : Logger {
-            private val delegate = ExpediaGroupLoggerFactory.getLogger(Client::class.java, it)
+            val delegate = ExpediaGroupLoggerFactory.getLogger(Client::class.java, it)
 
             override fun log(message: String) = delegate.info(message)
         }

--- a/core/src/main/kotlin/com/expediagroup/sdk/core/plugin/logging/LoggingPlugin.kt
+++ b/core/src/main/kotlin/com/expediagroup/sdk/core/plugin/logging/LoggingPlugin.kt
@@ -41,6 +41,7 @@ internal object LoggingPlugin : Plugin<LoggingConfiguration> {
                 client.getLoggingMaskedFieldsProvider().getMaskedHeaderFields().contains(header)
             }
         }
+        configurations.httpClientConfiguration.install(RequestBodyLogger)
         configurations.httpClientConfiguration.install(ResponseBodyLogger)
     }
 }

--- a/core/src/main/kotlin/com/expediagroup/sdk/core/plugin/logging/RequestBodyLogger.kt
+++ b/core/src/main/kotlin/com/expediagroup/sdk/core/plugin/logging/RequestBodyLogger.kt
@@ -1,0 +1,66 @@
+/*
+ * Copyright (C) 2022 Expedia, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.expediagroup.sdk.core.plugin.logging
+
+import com.expediagroup.sdk.core.constant.HeaderKey.TRANSACTION_ID
+import com.expediagroup.sdk.core.constant.LoggerName
+import com.expediagroup.sdk.core.constant.provider.LoggingMessageProvider
+import io.ktor.client.HttpClient
+import io.ktor.client.plugins.HttpClientPlugin
+import io.ktor.client.request.HttpRequestBuilder
+import io.ktor.client.request.HttpSendPipeline
+import io.ktor.http.HeadersBuilder
+import io.ktor.http.content.OutputStreamContent
+import io.ktor.util.AttributeKey
+import io.ktor.util.pipeline.PipelineContext
+import io.ktor.utils.io.ByteChannel
+
+internal class RequestBodyLogger {
+    private val log = ExpediaGroupLoggerFactory.getLogger(javaClass)
+
+    companion object Plugin : HttpClientPlugin<RequestBodyLoggerConfig, RequestBodyLogger> {
+        override val key: AttributeKey<RequestBodyLogger> = AttributeKey(LoggerName.REQUEST_BODY_LOGGER)
+
+        override fun install(
+            plugin: RequestBodyLogger,
+            scope: HttpClient
+        ) {
+            scope.sendPipeline.intercept(HttpSendPipeline.Monitoring) {
+                val body: String = getBody()
+                plugin.log.info(LoggingMessageProvider.getRequestBodyMessage(body, context.headers.getTransactionId()))
+                proceed()
+            }
+        }
+
+        private fun HeadersBuilder.getTransactionId(): String? = get(TRANSACTION_ID)
+
+        private suspend fun PipelineContext<Any, HttpRequestBuilder>.getBody(): String {
+            val body = context.body
+            if (body is OutputStreamContent) {
+                val channel = ByteChannel()
+                body.writeTo(channel)
+                return channel.readRemaining().readText()
+            }
+            return body.toString()
+        }
+
+        override fun prepare(block: RequestBodyLoggerConfig.() -> Unit): RequestBodyLogger {
+            return RequestBodyLogger()
+        }
+    }
+}
+
+internal class RequestBodyLoggerConfig

--- a/core/src/main/kotlin/com/expediagroup/sdk/core/plugin/logging/RequestBodyLogger.kt
+++ b/core/src/main/kotlin/com/expediagroup/sdk/core/plugin/logging/RequestBodyLogger.kt
@@ -40,7 +40,7 @@ internal class RequestBodyLogger {
         ) {
             scope.sendPipeline.intercept(HttpSendPipeline.Monitoring) {
                 val body: String = getBody()
-                plugin.log.info(LoggingMessageProvider.getRequestBodyMessage(body, context.headers.getTransactionId()))
+                plugin.log.debug(LoggingMessageProvider.getRequestBodyMessage(body, context.headers.getTransactionId()))
                 proceed()
             }
         }

--- a/core/src/main/kotlin/com/expediagroup/sdk/core/plugin/logging/RequestBodyLogger.kt
+++ b/core/src/main/kotlin/com/expediagroup/sdk/core/plugin/logging/RequestBodyLogger.kt
@@ -50,9 +50,10 @@ internal class RequestBodyLogger {
         private suspend fun PipelineContext<Any, HttpRequestBuilder>.getBody(): String {
             val body = context.body
             if (body is OutputStreamContent) {
-                val channel = ByteChannel()
-                body.writeTo(channel)
-                return channel.readRemaining().readText()
+                with(ByteChannel()) {
+                    body.writeTo(this)
+                    return readRemaining().readText()
+                }
             }
             return body.toString()
         }

--- a/core/src/main/kotlin/com/expediagroup/sdk/core/plugin/logging/ResponseBodyLogger.kt
+++ b/core/src/main/kotlin/com/expediagroup/sdk/core/plugin/logging/ResponseBodyLogger.kt
@@ -15,6 +15,7 @@
  */
 package com.expediagroup.sdk.core.plugin.logging
 
+import com.expediagroup.sdk.core.constant.HeaderKey
 import com.expediagroup.sdk.core.constant.HeaderValue
 import com.expediagroup.sdk.core.constant.LoggerName
 import com.expediagroup.sdk.core.constant.provider.LoggingMessageProvider
@@ -24,6 +25,7 @@ import io.ktor.client.plugins.HttpClientPlugin
 import io.ktor.client.plugins.compression.ContentEncoder
 import io.ktor.client.statement.HttpResponse
 import io.ktor.client.statement.HttpResponsePipeline
+import io.ktor.http.Headers
 import io.ktor.http.HttpHeaders
 import io.ktor.util.AttributeKey
 import io.ktor.util.Encoder
@@ -46,10 +48,12 @@ class ResponseBodyLogger {
                 val response: HttpResponse = context.response
                 val byteReadChannel: ByteReadChannel = if (response.contentEncoding().equals(HeaderValue.GZIP)) scope.decode(response.content) else response.content
                 val body: String = byteReadChannel.readRemaining().readText()
-                plugin.log.info(LoggingMessageProvider.getResponseBodyMessage(body))
+                plugin.log.info(LoggingMessageProvider.getResponseBodyMessage(body, response.headers.getTransactionId()))
                 proceed()
             }
         }
+
+        private fun Headers.getTransactionId(): String? = get(HeaderKey.TRANSACTION_ID)
 
         override fun prepare(block: ResponseBodyLoggerConfig.() -> Unit): ResponseBodyLogger {
             return ResponseBodyLogger()

--- a/core/src/main/kotlin/com/expediagroup/sdk/core/plugin/logging/ResponseBodyLogger.kt
+++ b/core/src/main/kotlin/com/expediagroup/sdk/core/plugin/logging/ResponseBodyLogger.kt
@@ -48,7 +48,7 @@ class ResponseBodyLogger {
                 val response: HttpResponse = context.response
                 val byteReadChannel: ByteReadChannel = if (response.contentEncoding().equals(HeaderValue.GZIP)) scope.decode(response.content) else response.content
                 val body: String = byteReadChannel.readRemaining().readText()
-                plugin.log.info(LoggingMessageProvider.getResponseBodyMessage(body, response.headers.getTransactionId()))
+                plugin.log.debug(LoggingMessageProvider.getResponseBodyMessage(body, response.headers.getTransactionId()))
                 proceed()
             }
         }


### PR DESCRIPTION
* [x] Code is up-to-date with the `main` branch.
* [x] You've successfully built and run the tests locally.
* [ ] There are new or updated unit tests validating the change.

### :pencil: Description
- Log request and response bodies independently from ktor (fixes duplicate response body logs)

### :link: Related Issues
N/A
