### PR TITLE
feat: add transaction-id and user-agent headers to Auth requests

### DIFF
--- a/core/src/main/kotlin/com/expediagroup/sdk/core/client/Environment.kt
+++ b/core/src/main/kotlin/com/expediagroup/sdk/core/client/Environment.kt
@@ -15,8 +15,10 @@
  */
 package com.expediagroup.sdk.core.client
 
+import com.expediagroup.sdk.core.constant.HeaderKey
 import com.expediagroup.sdk.core.model.Properties
 import io.ktor.client.request.HttpRequestBuilder
+import io.ktor.http.HttpHeaders
 import java.util.UUID
 
 interface EnvironmentProvider {
@@ -35,9 +37,9 @@ class DefaultEnvironmentProvider(
     @Suppress("MemberVisibilityCanBePrivate")
     override fun HttpRequestBuilder.appendHeaders(transactionId: UUID) {
         with(headers) {
-            append("User-agent", userAgent)
-            append("x-sdk-title", properties["sdk-title"]!!)
-            append("transaction-id", transactionId.toString())
+            append(HttpHeaders.UserAgent, userAgent)
+            append(HeaderKey.X_SDK_TITLE, properties["sdk-title"]!!)
+            append(HeaderKey.TRANSACTION_ID, transactionId.toString())
         }
     }
 }

--- a/core/src/main/kotlin/com/expediagroup/sdk/core/client/Environment.kt
+++ b/core/src/main/kotlin/com/expediagroup/sdk/core/client/Environment.kt
@@ -34,8 +34,10 @@ class DefaultEnvironmentProvider(
 
     @Suppress("MemberVisibilityCanBePrivate")
     override fun HttpRequestBuilder.appendHeaders(transactionId: UUID) {
-        headers.append("x-sdk-title", properties["sdk-title"]!!)
-        headers.append("transaction-id", transactionId.toString())
-        headers.append("User-agent", userAgent)
+        with(headers) {
+            append("User-agent", userAgent)
+            append("x-sdk-title", properties["sdk-title"]!!)
+            append("transaction-id", transactionId.toString())
+        }
     }
 }

--- a/core/src/main/kotlin/com/expediagroup/sdk/core/client/HttpHandler.kt
+++ b/core/src/main/kotlin/com/expediagroup/sdk/core/client/HttpHandler.kt
@@ -37,7 +37,7 @@ internal class DefaultHttpHandler(
         link: String
     ): HttpResponse {
         return httpClient.request {
-            method = HttpMethod.parse("GET")
+            method = HttpMethod.Get
             url(link)
             appendHeaders(UUID.randomUUID())
         }

--- a/core/src/main/kotlin/com/expediagroup/sdk/core/constant/HeaderKey.kt
+++ b/core/src/main/kotlin/com/expediagroup/sdk/core/constant/HeaderKey.kt
@@ -16,11 +16,11 @@
 package com.expediagroup.sdk.core.constant
 
 internal object HeaderKey {
-    const val AUTHORIZATION = "Authorization"
-
-    const val ACCEPT_ENCODING = "Accept-Encoding"
-
     const val PAGINATION_TOTAL_RESULTS = "pagination-total-results"
 
     const val LINK = "link"
+
+    const val TRANSACTION_ID = "transaction-id"
+
+    const val X_SDK_TITLE = "x-sdk-title"
 }

--- a/core/src/main/kotlin/com/expediagroup/sdk/core/plugin/authentication/AuthenticationHookFactory.kt
+++ b/core/src/main/kotlin/com/expediagroup/sdk/core/plugin/authentication/AuthenticationHookFactory.kt
@@ -17,14 +17,13 @@ package com.expediagroup.sdk.core.plugin.authentication
 
 import com.expediagroup.sdk.core.client.Client
 import com.expediagroup.sdk.core.constant.Authentication.AUTHORIZATION_REQUEST_LOCK_DELAY
-import com.expediagroup.sdk.core.constant.HeaderKey
 import com.expediagroup.sdk.core.plugin.Hook
 import com.expediagroup.sdk.core.plugin.HookBuilder
 import com.expediagroup.sdk.core.plugin.HookFactory
-import com.expediagroup.sdk.core.plugin.logging.ExpediaGroupLoggerFactory
 import io.ktor.client.plugins.HttpSend
 import io.ktor.client.plugins.plugin
 import io.ktor.client.request.HttpRequestBuilder
+import io.ktor.http.HttpHeaders
 import kotlinx.atomicfu.atomic
 import kotlinx.coroutines.delay
 
@@ -38,7 +37,6 @@ internal object AuthenticationHookFactory : HookFactory<AuthenticationConfigurat
 }
 
 private class AuthenticationHookBuilder(private val client: Client) : HookBuilder<AuthenticationConfiguration> {
-    private val log = ExpediaGroupLoggerFactory.getLogger(javaClass)
     private val lock = atomic(false)
     private val authenticationStrategy = client.getAuthenticationStrategy()
 
@@ -64,6 +62,6 @@ private class AuthenticationHookBuilder(private val client: Client) : HookBuilde
     }
 
     private fun assignLatestToken(request: HttpRequestBuilder) {
-        request.headers[HeaderKey.AUTHORIZATION] = authenticationStrategy.getAuthorizationHeader()
+        request.headers[HttpHeaders.Authorization] = authenticationStrategy.getAuthorizationHeader()
     }
 }

--- a/core/src/main/kotlin/com/expediagroup/sdk/core/plugin/authentication/AuthenticationPlugin.kt
+++ b/core/src/main/kotlin/com/expediagroup/sdk/core/plugin/authentication/AuthenticationPlugin.kt
@@ -30,7 +30,7 @@ internal object AuthenticationPlugin : Plugin<AuthenticationConfiguration> {
         client: Client,
         configurations: AuthenticationConfiguration
     ) {
-        val strategy = AuthenticationStrategy.from(configurations) { client.httpClient }
+        val strategy = AuthenticationStrategy.from(configurations, client)
         clientAuthenticationStrategies[client] = strategy
         configurations.httpClientConfiguration.install(Auth) {
             strategy.loadAuth(this)

--- a/core/src/main/kotlin/com/expediagroup/sdk/core/plugin/authentication/strategy/AuthenticationStrategy.kt
+++ b/core/src/main/kotlin/com/expediagroup/sdk/core/plugin/authentication/strategy/AuthenticationStrategy.kt
@@ -15,10 +15,10 @@
  */
 package com.expediagroup.sdk.core.plugin.authentication.strategy
 
+import com.expediagroup.sdk.core.client.Client
 import com.expediagroup.sdk.core.plugin.authentication.AuthenticationConfiguration
 import com.expediagroup.sdk.core.plugin.authentication.strategy.AuthenticationStrategy.AuthenticationType.BEARER
 import com.expediagroup.sdk.core.plugin.authentication.strategy.AuthenticationStrategy.AuthenticationType.SIGNATURE
-import io.ktor.client.HttpClient
 import io.ktor.client.plugins.auth.Auth
 import io.ktor.client.request.HttpRequestBuilder
 
@@ -36,10 +36,10 @@ internal interface AuthenticationStrategy {
     companion object {
         fun from(
             configs: AuthenticationConfiguration,
-            httpClientProvider: () -> HttpClient
+            client: Client
         ): AuthenticationStrategy =
             when (configs.authType) {
-                BEARER -> ExpediaGroupAuthenticationStrategy(httpClientProvider, configs)
+                BEARER -> ExpediaGroupAuthenticationStrategy(client, configs)
                 SIGNATURE -> RapidAuthenticationStrategy(configs)
             }
     }

--- a/core/src/main/kotlin/com/expediagroup/sdk/core/plugin/authentication/strategy/ExpediaGroupAuthenticationStrategy.kt
+++ b/core/src/main/kotlin/com/expediagroup/sdk/core/plugin/authentication/strategy/ExpediaGroupAuthenticationStrategy.kt
@@ -15,6 +15,7 @@
  */
 package com.expediagroup.sdk.core.plugin.authentication.strategy
 
+import com.expediagroup.sdk.core.client.Client
 import com.expediagroup.sdk.core.configuration.Credentials
 import com.expediagroup.sdk.core.constant.Authentication
 import com.expediagroup.sdk.core.constant.Constant
@@ -43,9 +44,10 @@ import io.ktor.http.clone
 import io.ktor.http.contentType
 import kotlinx.coroutines.runBlocking
 import java.time.LocalDateTime
+import java.util.UUID
 
 internal class ExpediaGroupAuthenticationStrategy(
-    private val httpClientProvider: () -> HttpClient,
+    private val client: Client,
     private val configs: AuthenticationConfiguration
 ) : AuthenticationStrategy {
     private val log = ExpediaGroupLoggerFactory.getLogger(javaClass)
@@ -62,7 +64,7 @@ internal class ExpediaGroupAuthenticationStrategy(
     override fun isTokenAboutToExpire(): Boolean = bearerTokenStorage.isAboutToExpire().also { if (it) log.info(LoggingMessage.TOKEN_EXPIRED) }
 
     override fun renewToken() {
-        val httpClient = httpClientProvider()
+        val httpClient = client.httpClient
         log.info(LoggingMessage.TOKEN_RENEWAL_IN_PROCESS)
         clearTokens(httpClient)
         val renewTokenResponse =
@@ -73,6 +75,7 @@ internal class ExpediaGroupAuthenticationStrategy(
                     contentType(ContentType.Application.FormUrlEncoded)
                     url(configs.authUrl)
                     basicAuth(configs.credentials)
+                    with(client) { appendHeaders(UUID.randomUUID()) }
                 }
             }
         if (renewTokenResponse.status.value !in Constant.SUCCESSFUL_STATUS_CODES_RANGE) {

--- a/core/src/main/kotlin/com/expediagroup/sdk/domain/rapid/RapidHelpers.kt
+++ b/core/src/main/kotlin/com/expediagroup/sdk/domain/rapid/RapidHelpers.kt
@@ -17,6 +17,7 @@ package com.expediagroup.sdk.domain.rapid
 
 import com.expediagroup.sdk.core.client.BaseRapidClient
 import com.expediagroup.sdk.core.client.ClientHelpers
+import com.expediagroup.sdk.core.constant.HeaderKey
 import com.expediagroup.sdk.core.model.Response
 
 class RapidHelpers(client: BaseRapidClient) : ClientHelpers(client) {
@@ -27,5 +28,5 @@ class RapidHelpers(client: BaseRapidClient) : ClientHelpers(client) {
     fun extractRoomBookingId(url: String): String? = Regex("rooms\\/([a-z0-9-]+)").find(url)?.groupValues?.getOrNull(1)
 
     /** Extracts the transaction ID from a response object if it exists; otherwise, returns null. */
-    fun <T> extractTransactionId(response: Response<T>): String? = response.headers.get("transaction-id")?.first()
+    fun <T> extractTransactionId(response: Response<T>): String? = response.headers[HeaderKey.TRANSACTION_ID]?.first()
 }

--- a/core/src/test/kotlin/com/expediagroup/sdk/core/authentication/strategy/ExpediaGroupAuthenticationStrategyTest.kt
+++ b/core/src/test/kotlin/com/expediagroup/sdk/core/authentication/strategy/ExpediaGroupAuthenticationStrategyTest.kt
@@ -88,8 +88,11 @@ internal class ExpediaGroupAuthenticationStrategyTest : AuthenticationPluginTest
             assertThat(authRequests.first().method).isEqualTo(HttpMethod.Post)
             assertThat(authRequests.first().headers[HttpHeaders.Authorization]).isEqualTo("${TestConstants.BASIC} ${TestConstants.ENCODED_CREDENTIALS}")
             assertThat(authRequests.first().headers[HttpHeaders.ContentType]).isEqualTo(ContentType.Application.FormUrlEncoded.toString())
+            assertThat(authRequests.first().headers[HeaderKey.X_SDK_TITLE]).isEqualTo("dummy-title")
+            assertThat(authRequests.first().headers[HttpHeaders.UserAgent]).isNotNull()
+            assertThat(authRequests.first().headers[HeaderKey.TRANSACTION_ID]).isNotNull()
 
-            assertThat(testRequest.request.headers[HeaderKey.AUTHORIZATION]).isEqualTo(
+            assertThat(testRequest.request.headers[HttpHeaders.Authorization]).isEqualTo(
                 "$BEARER $ACCESS_TOKEN"
             )
         }

--- a/core/src/test/kotlin/com/expediagroup/sdk/core/client/HttpHandlerTest.kt
+++ b/core/src/test/kotlin/com/expediagroup/sdk/core/client/HttpHandlerTest.kt
@@ -15,10 +15,12 @@
  */
 package com.expediagroup.sdk.core.client
 
+import com.expediagroup.sdk.core.constant.HeaderKey
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.mock.MockEngine
 import io.ktor.client.engine.mock.respond
 import io.ktor.http.Headers
+import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpStatusCode
 import io.ktor.util.flattenEntries
 import kotlinx.coroutines.runBlocking
@@ -55,9 +57,9 @@ class HttpHandlerTest {
 
             val requestHeaders = capturedRequestHeaders[0].flattenEntries().toMap()
 
-            assert(requestHeaders.containsKey("x-sdk-title") && requestHeaders["x-sdk-title"] == "dummy-title")
-            assert(requestHeaders.containsKey("User-agent"))
-            assert(requestHeaders.containsKey("transaction-id"))
+            assert(requestHeaders.containsKey(HeaderKey.X_SDK_TITLE) && requestHeaders[HeaderKey.X_SDK_TITLE] == "dummy-title")
+            assert(requestHeaders.containsKey(HttpHeaders.UserAgent))
+            assert(requestHeaders.containsKey(HeaderKey.TRANSACTION_ID))
         }
     }
 }

--- a/core/src/test/kotlin/com/expediagroup/sdk/core/plugin/authentication/AuthenticationPluginTest.kt
+++ b/core/src/test/kotlin/com/expediagroup/sdk/core/plugin/authentication/AuthenticationPluginTest.kt
@@ -17,7 +17,6 @@ package com.expediagroup.sdk.core.plugin.authentication
 
 import com.expediagroup.sdk.core.constant.Authentication.BEARER
 import com.expediagroup.sdk.core.constant.Authentication.EAN
-import com.expediagroup.sdk.core.constant.HeaderKey
 import com.expediagroup.sdk.core.model.exception.service.ExpediaGroupAuthException
 import com.expediagroup.sdk.core.test.ClientFactory
 import com.expediagroup.sdk.core.test.MockEngineFactory
@@ -26,6 +25,7 @@ import com.expediagroup.sdk.core.test.TestConstants.ANY_URL
 import com.expediagroup.sdk.core.test.TestConstants.CLIENT_KEY_TEST_CREDENTIAL
 import io.ktor.client.request.get
 import io.ktor.client.statement.request
+import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpStatusCode
 import io.mockk.clearAllMocks
 import io.mockk.mockkObject
@@ -60,12 +60,12 @@ internal open class AuthenticationPluginTest {
                 val signatureRequest = signatureHttpClient.get(ANY_URL)
                 val bearerRequest = bearerHttpClient.get(ANY_URL)
 
-                assertThat(bearerRequest.request.headers[HeaderKey.AUTHORIZATION]).isEqualTo(
+                assertThat(bearerRequest.request.headers[HttpHeaders.Authorization]).isEqualTo(
                     "$BEARER $ACCESS_TOKEN"
                 )
 
                 assertThat(
-                    signatureRequest.request.headers[HeaderKey.AUTHORIZATION]!!.startsWith("$EAN apikey=$CLIENT_KEY_TEST_CREDENTIAL,signature=")
+                    signatureRequest.request.headers[HttpHeaders.Authorization]!!.startsWith("$EAN apikey=$CLIENT_KEY_TEST_CREDENTIAL,signature=")
                 )
             }
         }

--- a/core/src/test/kotlin/com/expediagroup/sdk/core/plugin/authentication/strategy/AuthenticationStrategyTest.kt
+++ b/core/src/test/kotlin/com/expediagroup/sdk/core/plugin/authentication/strategy/AuthenticationStrategyTest.kt
@@ -17,10 +17,9 @@ package com.expediagroup.sdk.core.plugin.authentication.strategy
 
 import com.expediagroup.sdk.core.configuration.Credentials
 import com.expediagroup.sdk.core.plugin.authentication.AuthenticationConfiguration
+import com.expediagroup.sdk.core.test.ClientFactory.createExpediaGroupClient
 import com.expediagroup.sdk.core.test.TestConstants
-import io.ktor.client.HttpClient
 import io.ktor.client.HttpClientConfig
-import io.ktor.client.engine.okhttp.OkHttp
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -40,7 +39,7 @@ internal class AuthenticationStrategyTest {
                     "authEndpoint"
                 )
 
-            val strategy = AuthenticationStrategy.from(configuration) { HttpClient(OkHttp.create()) }
+            val strategy = AuthenticationStrategy.from(configuration, createExpediaGroupClient())
             assertThat(strategy is ExpediaGroupAuthenticationStrategy)
         }
     }

--- a/core/src/test/kotlin/com/expediagroup/sdk/core/plugin/authentication/strategy/RapidAuthenticationStrategyTest.kt
+++ b/core/src/test/kotlin/com/expediagroup/sdk/core/plugin/authentication/strategy/RapidAuthenticationStrategyTest.kt
@@ -16,7 +16,6 @@
 package com.expediagroup.sdk.core.plugin.authentication.strategy
 
 import com.expediagroup.sdk.core.constant.Authentication.EAN
-import com.expediagroup.sdk.core.constant.HeaderKey
 import com.expediagroup.sdk.core.plugin.authentication.AuthenticationPluginTest
 import com.expediagroup.sdk.core.plugin.authentication.getAuthenticationStrategy
 import com.expediagroup.sdk.core.test.ClientFactory
@@ -24,6 +23,7 @@ import com.expediagroup.sdk.core.test.TestConstants
 import com.expediagroup.sdk.core.test.TestConstants.ANY_URL
 import io.ktor.client.request.get
 import io.ktor.client.statement.request
+import io.ktor.http.HttpHeaders
 import io.mockk.mockkObject
 import io.mockk.verify
 import kotlinx.coroutines.delay
@@ -40,7 +40,7 @@ internal class RapidAuthenticationStrategyTest : AuthenticationPluginTest() {
             val request = httpClient.get(ANY_URL)
 
             assertThat(
-                request.request.headers[HeaderKey.AUTHORIZATION]!!.startsWith("$EAN apikey=${TestConstants.CLIENT_KEY_TEST_CREDENTIAL},signature=")
+                request.request.headers[HttpHeaders.Authorization]!!.startsWith("$EAN apikey=${TestConstants.CLIENT_KEY_TEST_CREDENTIAL},signature=")
             )
         }
     }
@@ -54,8 +54,8 @@ internal class RapidAuthenticationStrategyTest : AuthenticationPluginTest() {
             delay(1000)
             val secondRequest = httpClient.get(ANY_URL)
 
-            val firstRequestAuth = firstRequest.request.headers[HeaderKey.AUTHORIZATION]
-            val secondRequestAuth = secondRequest.request.headers[HeaderKey.AUTHORIZATION]
+            val firstRequestAuth = firstRequest.request.headers[HttpHeaders.Authorization]
+            val secondRequestAuth = secondRequest.request.headers[HttpHeaders.Authorization]
 
             assertThat(firstRequestAuth).isNotNull
             assertThat(secondRequestAuth).isNotNull

--- a/core/src/test/kotlin/com/expediagroup/sdk/core/plugin/encoding/EncodingPluginTest.kt
+++ b/core/src/test/kotlin/com/expediagroup/sdk/core/plugin/encoding/EncodingPluginTest.kt
@@ -15,7 +15,6 @@
  */
 package com.expediagroup.sdk.core.plugin.encoding
 
-import com.expediagroup.sdk.core.constant.HeaderKey
 import com.expediagroup.sdk.core.constant.HeaderValue.GZIP
 import com.expediagroup.sdk.core.test.ClientFactory
 import com.expediagroup.sdk.core.test.TestConstants.ANY_URL
@@ -46,7 +45,7 @@ internal class EncodingPluginTest {
             val httpClient = ClientFactory.createExpediaGroupClient().httpClient
             val testRequest = httpClient.get(ANY_URL)
 
-            Assertions.assertThat(testRequest.request.headers[HeaderKey.ACCEPT_ENCODING]).isEqualTo(
+            Assertions.assertThat(testRequest.request.headers[HttpHeaders.AcceptEncoding]).isEqualTo(
                 GZIP
             )
         }

--- a/core/src/test/kotlin/com/expediagroup/sdk/core/test/MockEngineFactory.kt
+++ b/core/src/test/kotlin/com/expediagroup/sdk/core/test/MockEngineFactory.kt
@@ -18,7 +18,6 @@ package com.expediagroup.sdk.core.test
 import com.expediagroup.sdk.core.configuration.provider.ExpediaGroupConfigurationProvider
 import com.expediagroup.sdk.core.constant.Authentication.BEARER
 import com.expediagroup.sdk.core.constant.Constant.EMPTY_STRING
-import com.expediagroup.sdk.core.constant.HeaderKey
 import com.expediagroup.sdk.core.model.exception.service.ExpediaGroupAuthException
 import com.expediagroup.sdk.core.test.TestConstants.ACCESS_TOKEN
 import com.expediagroup.sdk.core.test.TestConstants.APPLICATION_JSON
@@ -140,9 +139,9 @@ object MockEngineFactory {
 
     private fun isBadRequest(request: HttpRequestData): Boolean = request.attributes.getOrNull(AttributeKey(BAD_REQUEST_ATTRIBUTE)) != null
 
-    private fun isValidCredentialsRequest(request: HttpRequestData) = request.headers[HeaderKey.AUTHORIZATION] == "$BASIC ${TestConstants.ENCODED_CREDENTIALS}"
+    private fun isValidCredentialsRequest(request: HttpRequestData) = request.headers[HttpHeaders.Authorization] == "$BASIC ${TestConstants.ENCODED_CREDENTIALS}"
 
-    private fun isAuthorizedHeader(request: HttpRequestData): Boolean = request.headers[HeaderKey.AUTHORIZATION] == "$BEARER $ACCESS_TOKEN"
+    private fun isAuthorizedHeader(request: HttpRequestData): Boolean = request.headers[HttpHeaders.Authorization] == "$BEARER $ACCESS_TOKEN"
 
     private fun MockRequestHandleScope.tokenResponse(httpStatusCode: HttpStatusCode): HttpResponseData =
         respond(


### PR DESCRIPTION
* [x] Code is up-to-date with the `main` branch.
* [x] You've successfully built and run the tests locally.
* [x] There are new or updated unit tests validating the change.

### :pencil: Description
- Add transaction-id and user-agent headers to Auth requests

### :link: Related Issues
N/A
