### PR TITLE
fix: mask access_token in logs

### DIFF
--- a/core/src/main/kotlin/com/expediagroup/sdk/core/constant/LogMaskingFields.kt
+++ b/core/src/main/kotlin/com/expediagroup/sdk/core/constant/LogMaskingFields.kt
@@ -26,6 +26,7 @@ internal data object LogMaskingFields {
             "card_cvv",
             "card_cvv2",
             "card_number",
+            "access_token",
             "security_code",
             "account_number",
             "card_avs_response",

--- a/core/src/test/kotlin/com/expediagroup/sdk/core/plugin/logging/LogMaskerTest.kt
+++ b/core/src/test/kotlin/com/expediagroup/sdk/core/plugin/logging/LogMaskerTest.kt
@@ -35,6 +35,7 @@ internal class LogMaskerTest {
                 "card_avs_response",
                 "pin",
                 "card_cvv",
+                "access_token",
                 "account_number",
                 "card_cvv2",
                 "card_cvv2_response",


### PR DESCRIPTION
* [x] Code is up-to-date with the `main` branch.
* [x] You've successfully built and run the tests locally.
* [x] There are new or updated unit tests validating the change.

### :pencil: Description
- Mask access_token in logs

### :link: Related Issues
N/A
