### PR TITLE
feat: add an eventlistener for logging okhttp events

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -181,6 +181,12 @@
                     <groupId>org.jetbrains.kotlin</groupId>
                     <artifactId>kotlin-stdlib</artifactId>
                 </dependency>
+
+                <dependency>
+                    <groupId>com.squareup.okhttp3</groupId>
+                    <artifactId>okhttp</artifactId>
+                    <version>4.12.0</version>
+                </dependency>
             </dependencies>
 
             <build>

--- a/core/src/main/kotlin/com/expediagroup/sdk/core/client/Client.kt
+++ b/core/src/main/kotlin/com/expediagroup/sdk/core/client/Client.kt
@@ -46,8 +46,14 @@ import io.ktor.client.HttpClient
 import io.ktor.client.engine.HttpClientEngine
 import io.ktor.client.engine.okhttp.OkHttp
 import io.ktor.client.statement.HttpResponse
+import main.kotlin.com.expediagroup.sdk.core.client.OkHttpEventListener
 
-val DEFAULT_HTTP_CLIENT_ENGINE: HttpClientEngine = OkHttp.create()
+val DEFAULT_HTTP_CLIENT_ENGINE: HttpClientEngine =
+    OkHttp.create {
+        config {
+            eventListener(OkHttpEventListener())
+        }
+    }
 
 /**
  * The base integration point between the SDK Core and the product SDKs.

--- a/core/src/main/kotlin/com/expediagroup/sdk/core/client/Client.kt
+++ b/core/src/main/kotlin/com/expediagroup/sdk/core/client/Client.kt
@@ -46,12 +46,11 @@ import io.ktor.client.HttpClient
 import io.ktor.client.engine.HttpClientEngine
 import io.ktor.client.engine.okhttp.OkHttp
 import io.ktor.client.statement.HttpResponse
-import main.kotlin.com.expediagroup.sdk.core.client.OkHttpEventListener
 
 val DEFAULT_HTTP_CLIENT_ENGINE: HttpClientEngine =
     OkHttp.create {
         config {
-            eventListener(OkHttpEventListener())
+            eventListener(OkHttpEventListener)
         }
     }
 

--- a/core/src/main/kotlin/com/expediagroup/sdk/core/client/OkHttpEventListener.kt
+++ b/core/src/main/kotlin/com/expediagroup/sdk/core/client/OkHttpEventListener.kt
@@ -1,0 +1,132 @@
+/*
+ * Copyright (C) 2022 Expedia, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package main.kotlin.com.expediagroup.sdk.core.client
+
+import com.expediagroup.sdk.core.plugin.logging.ExpediaGroupLoggerFactory
+import okhttp3.Call
+import okhttp3.Connection
+import okhttp3.EventListener
+import okhttp3.Handshake
+import okhttp3.Protocol
+import java.io.IOException
+import java.net.InetAddress
+import java.net.InetSocketAddress
+import java.net.Proxy
+
+class OkHttpEventListener : EventListener() {
+    companion object {
+        private val log = ExpediaGroupLoggerFactory.getLogger(this::class.java)
+    }
+
+    override fun callStart(call: Call) {
+        super.callStart(call)
+        log.debug("call start")
+    }
+
+    override fun callEnd(call: Call) {
+        super.callEnd(call)
+        log.debug("call end")
+    }
+
+    override fun dnsStart(
+        call: Call,
+        domainName: String
+    ) {
+        super.dnsStart(call, domainName)
+        log.debug("dns lookup start for domain: %s".format(domainName))
+    }
+
+    override fun dnsEnd(
+        call: Call,
+        domainName: String,
+        inetAddressList: List<InetAddress>
+    ) {
+        super.dnsEnd(call, domainName, inetAddressList)
+        log.debug("dns lookup end for domain: %s".format(domainName))
+    }
+
+    override fun callFailed(
+        call: Call,
+        ioe: IOException
+    ) {
+        super.callFailed(call, ioe)
+        log.debug("call failed with exception: %s".format(ioe.message))
+    }
+
+    override fun canceled(call: Call) {
+        super.canceled(call)
+        log.debug("call canceled")
+    }
+
+    override fun connectStart(
+        call: Call,
+        inetSocketAddress: InetSocketAddress,
+        proxy: Proxy
+    ) {
+        super.connectStart(call, inetSocketAddress, proxy)
+        log.debug("connect start")
+    }
+
+    override fun connectEnd(
+        call: Call,
+        inetSocketAddress: InetSocketAddress,
+        proxy: Proxy,
+        protocol: Protocol?
+    ) {
+        super.connectEnd(call, inetSocketAddress, proxy, protocol)
+        log.debug("connect end")
+    }
+
+    override fun connectFailed(
+        call: Call,
+        inetSocketAddress: InetSocketAddress,
+        proxy: Proxy,
+        protocol: Protocol?,
+        ioe: IOException
+    ) {
+        super.connectFailed(call, inetSocketAddress, proxy, protocol, ioe)
+        log.debug("connect failed with exception: %s".format(ioe.message))
+    }
+
+    override fun connectionAcquired(
+        call: Call,
+        connection: Connection
+    ) {
+        super.connectionAcquired(call, connection)
+        log.debug("connection acquired")
+    }
+
+    override fun connectionReleased(
+        call: Call,
+        connection: Connection
+    ) {
+        super.connectionReleased(call, connection)
+        log.debug("connection released")
+    }
+
+    override fun secureConnectStart(call: Call) {
+        super.secureConnectStart(call)
+        log.debug("secure connect start")
+    }
+
+    override fun secureConnectEnd(
+        call: Call,
+        handshake: Handshake?
+    ) {
+        super.secureConnectEnd(call, handshake)
+        log.debug("secure connect end")
+    }
+}

--- a/core/src/main/kotlin/com/expediagroup/sdk/core/client/OkHttpEventListener.kt
+++ b/core/src/main/kotlin/com/expediagroup/sdk/core/client/OkHttpEventListener.kt
@@ -13,49 +13,34 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package main.kotlin.com.expediagroup.sdk.core.client
+package com.expediagroup.sdk.core.client
 
+import com.expediagroup.sdk.core.constant.HeaderKey
 import com.expediagroup.sdk.core.plugin.logging.ExpediaGroupLoggerFactory
 import okhttp3.Call
 import okhttp3.Connection
 import okhttp3.EventListener
 import okhttp3.Handshake
 import okhttp3.Protocol
+import okhttp3.Request
+import okhttp3.Response
 import java.io.IOException
-import java.net.InetAddress
 import java.net.InetSocketAddress
 import java.net.Proxy
 
-class OkHttpEventListener : EventListener() {
-    companion object {
-        private val log = ExpediaGroupLoggerFactory.getLogger(this::class.java)
-    }
+object OkHttpEventListener : EventListener() {
+    private val log = ExpediaGroupLoggerFactory.getLogger(this::class.java)
+
+    fun Call.getTransactionId() = request().headers[HeaderKey.TRANSACTION_ID]
 
     override fun callStart(call: Call) {
         super.callStart(call)
-        log.debug("call start")
+        log.debug("Call start for transaction-id: [${call.getTransactionId()}]")
     }
 
     override fun callEnd(call: Call) {
         super.callEnd(call)
-        log.debug("call end")
-    }
-
-    override fun dnsStart(
-        call: Call,
-        domainName: String
-    ) {
-        super.dnsStart(call, domainName)
-        log.debug("dns lookup start for domain: %s".format(domainName))
-    }
-
-    override fun dnsEnd(
-        call: Call,
-        domainName: String,
-        inetAddressList: List<InetAddress>
-    ) {
-        super.dnsEnd(call, domainName, inetAddressList)
-        log.debug("dns lookup end for domain: %s".format(domainName))
+        log.debug("Call end for transaction-id: [${call.getTransactionId()}]")
     }
 
     override fun callFailed(
@@ -63,12 +48,12 @@ class OkHttpEventListener : EventListener() {
         ioe: IOException
     ) {
         super.callFailed(call, ioe)
-        log.debug("call failed with exception: %s".format(ioe.message))
+        log.debug("Call failed for transaction-id: [${call.getTransactionId()}] with exception message: ${ioe.message}")
     }
 
     override fun canceled(call: Call) {
         super.canceled(call)
-        log.debug("call canceled")
+        log.debug("Call canceled for transaction-id: [${call.getTransactionId()}]")
     }
 
     override fun connectStart(
@@ -77,7 +62,7 @@ class OkHttpEventListener : EventListener() {
         proxy: Proxy
     ) {
         super.connectStart(call, inetSocketAddress, proxy)
-        log.debug("connect start")
+        log.debug("Connect start for transaction-id: [${call.getTransactionId()}]")
     }
 
     override fun connectEnd(
@@ -87,7 +72,7 @@ class OkHttpEventListener : EventListener() {
         protocol: Protocol?
     ) {
         super.connectEnd(call, inetSocketAddress, proxy, protocol)
-        log.debug("connect end")
+        log.debug("Connect end for transaction-id: [${call.getTransactionId()}]")
     }
 
     override fun connectFailed(
@@ -98,7 +83,7 @@ class OkHttpEventListener : EventListener() {
         ioe: IOException
     ) {
         super.connectFailed(call, inetSocketAddress, proxy, protocol, ioe)
-        log.debug("connect failed with exception: %s".format(ioe.message))
+        log.debug("Connect failed for transaction-id: [${call.getTransactionId()}] with exception message: ${ioe.message}")
     }
 
     override fun connectionAcquired(
@@ -106,7 +91,7 @@ class OkHttpEventListener : EventListener() {
         connection: Connection
     ) {
         super.connectionAcquired(call, connection)
-        log.debug("connection acquired")
+        log.debug("Connection acquired for transaction-id: [${call.getTransactionId()}]")
     }
 
     override fun connectionReleased(
@@ -114,12 +99,12 @@ class OkHttpEventListener : EventListener() {
         connection: Connection
     ) {
         super.connectionReleased(call, connection)
-        log.debug("connection released")
+        log.debug("Connection released for transaction-id: [${call.getTransactionId()}]")
     }
 
     override fun secureConnectStart(call: Call) {
         super.secureConnectStart(call)
-        log.debug("secure connect start")
+        log.debug("Secure connect start for transaction-id: [${call.getTransactionId()}]")
     }
 
     override fun secureConnectEnd(
@@ -127,6 +112,74 @@ class OkHttpEventListener : EventListener() {
         handshake: Handshake?
     ) {
         super.secureConnectEnd(call, handshake)
-        log.debug("secure connect end")
+        log.debug("Secure connect end for transaction-id: [${call.getTransactionId()}]")
+    }
+
+    override fun requestHeadersStart(call: Call) {
+        super.requestHeadersStart(call)
+        log.debug("Sending request headers start for transaction-id: [${call.getTransactionId()}]")
+    }
+
+    override fun requestHeadersEnd(
+        call: Call,
+        request: Request
+    ) {
+        super.requestHeadersEnd(call, request)
+        log.debug("Sending request headers end for transaction-id: [${call.getTransactionId()}]")
+    }
+
+    override fun requestBodyStart(call: Call) {
+        super.requestBodyStart(call)
+        log.debug("Sending request body start for transaction-id: [${call.getTransactionId()}]")
+    }
+
+    override fun requestBodyEnd(
+        call: Call,
+        byteCount: Long
+    ) {
+        super.requestBodyEnd(call, byteCount)
+        log.debug("Sending request body end for transaction-id: [${call.getTransactionId()}] with byte count: $byteCount")
+    }
+
+    override fun requestFailed(
+        call: Call,
+        ioe: IOException
+    ) {
+        super.requestFailed(call, ioe)
+        log.debug("Request failed for transaction-id: [${call.getTransactionId()}] with exception message: ${ioe.message}")
+    }
+
+    override fun responseHeadersStart(call: Call) {
+        super.responseHeadersStart(call)
+        log.debug("Receiving response headers start for transaction-id: [${call.getTransactionId()}]")
+    }
+
+    override fun responseHeadersEnd(
+        call: Call,
+        response: Response
+    ) {
+        super.responseHeadersEnd(call, response)
+        log.debug("Receiving response headers end for transaction-id: [${call.getTransactionId()}]")
+    }
+
+    override fun responseBodyStart(call: Call) {
+        super.responseBodyStart(call)
+        log.debug("Receiving response body start for transaction-id: [${call.getTransactionId()}]")
+    }
+
+    override fun responseBodyEnd(
+        call: Call,
+        byteCount: Long
+    ) {
+        super.responseBodyEnd(call, byteCount)
+        log.debug("Receiving response body end for transaction-id: [${call.getTransactionId()}] with byte count: $byteCount")
+    }
+
+    override fun responseFailed(
+        call: Call,
+        ioe: IOException
+    ) {
+        super.responseFailed(call, ioe)
+        log.debug("Receiving response failed for transaction-id: [${call.getTransactionId()}] with exception message: ${ioe.message}")
     }
 }

--- a/core/src/main/kotlin/com/expediagroup/sdk/core/plugin/logging/ExpediaGroupLogger.kt
+++ b/core/src/main/kotlin/com/expediagroup/sdk/core/plugin/logging/ExpediaGroupLogger.kt
@@ -25,6 +25,8 @@ internal class ExpediaGroupLogger(private val logger: Logger, private val client
 
     override fun warn(msg: String) = logger.warn(decorate(msg))
 
+    override fun debug(msg: String) = logger.debug(decorate(msg))
+
     private fun decorate(msg: String): String = "$LOGGING_PREFIX ${mask(msg, getMaskedBodyFields())}"
 
     private fun getMaskedBodyFields(): Set<String> = client?.getLoggingMaskedFieldsProvider()?.getMaskedBodyFields() ?: LogMaskingFields.DEFAULT_MASKED_BODY_FIELDS

--- a/pom.xml
+++ b/pom.xml
@@ -400,6 +400,8 @@
 
                             <exclude>**/client/*Client*</exclude>
 
+                            <exclude>**/client/*EventListener*</exclude>
+
                             <exclude>**/configuration/**ClientBuilder*</exclude>
                             <exclude>**/configuration/NetworkConfiguration*</exclude>
                             <exclude>**/config/**</exclude>


### PR DESCRIPTION
### :pencil: Description
- When debug log level is enabled, developer can see logs for okhttp events associated with transaction-id describing the following the events for every transaction:
1. Call start
2. Call end
3. Send Req Headers Start
4. Send Req Headers End
5. Send Req Body Start
6. Send Req Body End
7. Failed Request
8. Receive Resp Headers Start
9. Receive Resp Headers End
10. Receive Resp Body Start
11. Receive Resp Body End
12. Receive Resp Failed
13. Call failed
14. Call canceled
15. Connect start
16. Connect end
17. Connect failed
18. Connection acquired
19. Connection released
20. Secure connect start
21. Secure connect end

Example: 

```
2024-02-08T16:34:20.879+03:00 DEBUG 68372 --- [alhost:3000/...] c.e.sdk.core.client.OkHttpEventListener  : ExpediaSDK: Receiving response headers start for transaction-id: [dc668f89-b2bf-438f-9ee7-35f226c87911]
2024-02-08T16:34:20.880+03:00 DEBUG 68372 --- [alhost:3000/...] c.e.sdk.core.client.OkHttpEventListener  : ExpediaSDK: Receiving response headers end for transaction-id: [dc668f89-b2bf-438f-9ee7-35f226c87911]
2024-02-08T16:34:20.880+03:00 DEBUG 68372 --- [atcher-worker-2] c.e.sdk.core.client.OkHttpEventListener  : ExpediaSDK: Receiving response body start for transaction-id: [dc668f89-b2bf-438f-9ee7-35f226c87911]
2024-02-08T16:34:20.880+03:00 DEBUG 68372 --- [atcher-worker-2] c.e.sdk.core.client.OkHttpEventListener  : ExpediaSDK: Receiving response body end for transaction-id: [dc668f89-b2bf-438f-9ee7-35f226c87911] with byte count: 2468
```
