### PR TITLE
fix: update github token name in draft release generator

### DIFF
--- a/.github/workflows/generator-draft-release.yaml
+++ b/.github/workflows/generator-draft-release.yaml
@@ -18,7 +18,7 @@ jobs:
       - name: Create tag
         uses: actions/github-script@v7
         with:
-          github-token: ${{ secrets.GH_PAT }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             github.rest.git.createRef({
               owner: context.repo.owner,

--- a/.github/workflows/generator-main.yaml
+++ b/.github/workflows/generator-main.yaml
@@ -51,7 +51,7 @@ jobs:
     with:
       production_release: ${{ github.event.inputs.production_release == 'true' }}
   draft_release:
-    if: ${{ github.event.inputs.production_release == 'false' }}
+    if: ${{ github.event.inputs.production_release == 'true' }}
     needs: [ generate ]
     secrets: inherit
     uses: ./.github/workflows/generator-draft-release.yaml

--- a/.github/workflows/generator-main.yaml
+++ b/.github/workflows/generator-main.yaml
@@ -51,7 +51,7 @@ jobs:
     with:
       production_release: ${{ github.event.inputs.production_release == 'true' }}
   draft_release:
-    if: ${{ github.event.inputs.production_release == 'true' }}
+    if: ${{ github.event.inputs.production_release == 'false' }}
     needs: [ generate ]
     secrets: inherit
     uses: ./.github/workflows/generator-draft-release.yaml


### PR DESCRIPTION
## Situation
Whenever a new SDK generation workflow is triggered through the [generator-main.yaml](https://github.com/ExpediaGroup/expediagroup-java-sdk/blob/main/.github/workflows/generator-main.yaml) workflow, a release draft is created by triggering the [generator-draft-release.yaml](https://github.com/ExpediaGroup/expediagroup-java-sdk/blob/main/.github/workflows/generator-draft-release.yaml) workflow.

In the `generator-draft-release.yaml`, we are using one of our repository secrets, more specifically, the GitHub personal access token. The token is used to create a new release tag. The issue is that the used token name is `GH_PAT`, meanwhile the actual token name is `GITHUB_TOKEN `.

This results in a `404` response from the GitHub API, the reason it is a `404` and not a `403` is described in detail in [GitHub API docs](https://docs.github.com/en/rest/using-the-rest-api/troubleshooting-the-rest-api?apiVersion=2022-11-28#404-not-found-for-an-existing-resource).

## Task
Update the used token name to enable the action to be able to authenticate with Github API.

## Action
### Old token name:
```yaml
github-token: ${{ secrets.GH_PAT }}
```

### Updated token name
```yaml
github-token: ${{ secrets.GITHUB_TOKEN }}
```

## Result
The action now behaves as expected, please check [this workflow run](https://github.com/ExpediaGroup/expediagroup-java-sdk/actions/runs/8412125601/job/23032624069), which is used for testing purposes.