### PR TITLE
fix: threads freeze on waiting state when logging request body through custom logger

### DIFF
--- a/core/src/main/kotlin/com/expediagroup/sdk/core/plugin/logging/LoggingPlugin.kt
+++ b/core/src/main/kotlin/com/expediagroup/sdk/core/plugin/logging/LoggingPlugin.kt
@@ -41,7 +41,7 @@ internal object LoggingPlugin : Plugin<LoggingConfiguration> {
                 client.getLoggingMaskedFieldsProvider().getMaskedHeaderFields().contains(header)
             }
         }
-        // configurations.httpClientConfiguration.install(RequestBodyLogger)
+        configurations.httpClientConfiguration.install(RequestBodyLogger)
         configurations.httpClientConfiguration.install(ResponseBodyLogger)
     }
 }


### PR DESCRIPTION
## Situation
In pull request #446, a new requests logger was introduced, which logs requests separately from ktor client. The custom logger intercepts the [`HttpSendPipeline`](https://api.ktor.io/ktor-client/ktor-client-core/io.ktor.client.request/-http-send-pipeline/index.html) on [`Monitoring Phase`](https://api.ktor.io/ktor-client/ktor-client-core/io.ktor.client.request/-http-send-pipeline/-phases/-monitoring.html). 

For each request intercepted, an [`HttpRequestBuilder`](https://api.ktor.io/ktor-client/ktor-client-core/io.ktor.client.request/-http-request-builder/index.html) instance is available for read operations. The `HttpRequestBuilder` allows access for a few attributes request such as [`body`](https://api.ktor.io/ktor-client/ktor-client-core/io.ktor.client.call/body.html) and [`headers`](https://api.ktor.io/ktor-client/ktor-client-core/io.ktor.client.request/-http-request-builder/headers.html). 

Since an interceptor would not necessarily attempt to read the `body` attribute, its type, based on its size, can be one of two types:
1) `String`: Default type.
2) [`OutputStreamContent`](https://api.ktor.io/ktor-http/io.ktor.http.content/-output-stream-content/index.html): In the case of large request bodies, which can be costly to read and transform into a `String` type.

In the case of large request bodies, we attempt to write the data exposed by the `OutputStreamContent` body into a manually-managed [`ByteChannel`](https://api.ktor.io/ktor-io/io.ktor.utils.io/-byte-channel/index.html) instance, read the bytes written into the `ByteChannel`, and decode the bytes into a `utf-8` text afterwards. 

```kotlin
with(ByteChannel()) {
    body.writeTo(this)
    return readRemaining().readText()
}
```

The [`writeTo`](https://api.ktor.io/ktor-http/io.ktor.http.content/-output-stream-content/write-to.html) method, which us used in the previous implementation to write data into the `ByteChannel` is run inside a [`withBlocking`](https://github.com/ktorio/ktor/blob/6763a7344059c1f9dfdb2f0816e98559862ef604/ktor-http/jvm/src/io/ktor/http/content/BlockingBridge.kt#L26) scope.

For some reason, when the write operation is triggered, at some point the writing execution thread, along with all other threads, go into a waiting state. Please check the following [thread dump](https://www.perfmatrix.com/thread-dump-overview/) below, which is generated by [VisualVM](https://visualvm.github.io/), in order to have a clear image of threads state after the writing operation is triggered. Based on my own observations and opinion, the threads dump is indicating a state somewhat similar to a [deadlock](https://en.wikipedia.org/wiki/Deadlock).
<details>
<summary><b>Threads Dump</b></summary>

    2024-04-02 22:01:51 
    Full thread dump OpenJDK 64-Bit Server VM (18.0.2.1+1-1 mixed mode, sharing):
    
    Threads class SMR info:
    _java_thread_list=0x00006000007eeea0, length=29, elements={
    0x000000014d809800, 0x000000012c808200, 0x000000014d809000, 0x000000012c809e00,
    0x000000014d010000, 0x000000014d010600, 0x000000012c808e00, 0x000000014d80ae00,
    0x000000014d819600, 0x000000014d81a600, 0x000000012c80a400, 0x000000014d819000,
    0x000000013d830600, 0x000000014d0c7e00, 0x000000012c80aa00, 0x000000012c8d9e00,
    0x000000012d185400, 0x000000013d0b4a00, 0x000000014d0dca00, 0x000000013d11e400,
    0x000000013d11ea00, 0x000000013e825400, 0x000000012f846000, 0x000000014d9c9c00,
    0x000000012c8cd600, 0x000000013d83ae00, 0x000000014d8eca00, 0x000000014e825600,
    0x000000012c8ce200
    }
    
    "main" #1 prio=5 os_prio=31 cpu=361.96ms elapsed=6.98s tid=0x000000014d809800 nid=8963 waiting on condition  [0x000000016b9be000]
       java.lang.Thread.State: WAITING (parking)
            at jdk.internal.misc.Unsafe.park(java.base@18.0.2.1/Native Method)
            - parking to wait for  <0x0000000700400000> (a java.util.concurrent.CompletableFuture$Signaller)
            at java.util.concurrent.locks.LockSupport.park(java.base@18.0.2.1/LockSupport.java:211)
            at java.util.concurrent.CompletableFuture$Signaller.block(java.base@18.0.2.1/CompletableFuture.java:1864)
            at java.util.concurrent.ForkJoinPool.unmanagedBlock(java.base@18.0.2.1/ForkJoinPool.java:3464)
            at java.util.concurrent.ForkJoinPool.managedBlock(java.base@18.0.2.1/ForkJoinPool.java:3435)
            at java.util.concurrent.CompletableFuture.waitingGet(java.base@18.0.2.1/CompletableFuture.java:1898)
            at java.util.concurrent.CompletableFuture.get(java.base@18.0.2.1/CompletableFuture.java:2072)
            at com.expediagroup.sdk.fraudpreventionv2.client.FraudPreventionV2Client.screenOrderWithResponse(FraudPreventionV2Client.kt:408)
            at com.expediagroup.sdk.fraudpreventionv2.client.FraudPreventionV2Client.screenOrder(FraudPreventionV2Client.kt:374)
            at org.jarrah.Main.main(Main.java:33)
    
       Locked ownable synchronizers:
            - None
    
    "Reference Handler" #2 daemon prio=10 os_prio=31 cpu=0.50ms elapsed=6.97s tid=0x000000012c808200 nid=17667 waiting on condition  [0x000000016c812000]
       java.lang.Thread.State: RUNNABLE
            at java.lang.ref.Reference.waitForReferencePendingList(java.base@18.0.2.1/Native Method)
            at java.lang.ref.Reference.processPendingReferences(java.base@18.0.2.1/Reference.java:253)
            at java.lang.ref.Reference$ReferenceHandler.run(java.base@18.0.2.1/Reference.java:215)
    
       Locked ownable synchronizers:
            - None
    
    "Finalizer" #3 daemon prio=8 os_prio=31 cpu=0.11ms elapsed=6.97s tid=0x000000014d809000 nid=17923 in Object.wait()  [0x000000016ca1e000]
       java.lang.Thread.State: WAITING (on object monitor)
            at java.lang.Object.wait(java.base@18.0.2.1/Native Method)
            - waiting on <0x0000000700001b18> (a java.lang.ref.ReferenceQueue$Lock)
            at java.lang.ref.ReferenceQueue.remove(java.base@18.0.2.1/ReferenceQueue.java:155)
            - locked <0x0000000700001b18> (a java.lang.ref.ReferenceQueue$Lock)
            at java.lang.ref.ReferenceQueue.remove(java.base@18.0.2.1/ReferenceQueue.java:176)
            at java.lang.ref.Finalizer$FinalizerThread.run(java.base@18.0.2.1/Finalizer.java:183)
    
       Locked ownable synchronizers:
            - None
    
    "Signal Dispatcher" #4 daemon prio=9 os_prio=31 cpu=0.43ms elapsed=6.96s tid=0x000000012c809e00 nid=24067 waiting on condition  [0x0000000000000000]
       java.lang.Thread.State: RUNNABLE
    
       Locked ownable synchronizers:
            - None
    
    "Service Thread" #5 daemon prio=9 os_prio=31 cpu=0.18ms elapsed=6.96s tid=0x000000014d010000 nid=31747 runnable  [0x0000000000000000]
       java.lang.Thread.State: RUNNABLE
    
       Locked ownable synchronizers:
            - None
    
    "Monitor Deflation Thread" #6 daemon prio=9 os_prio=31 cpu=0.09ms elapsed=6.96s tid=0x000000014d010600 nid=24323 runnable  [0x0000000000000000]
       java.lang.Thread.State: RUNNABLE
    
       Locked ownable synchronizers:
            - None
    
    "C2 CompilerThread0" #7 daemon prio=9 os_prio=31 cpu=1230.54ms elapsed=6.96s tid=0x000000012c808e00 nid=24835 waiting on condition  [0x0000000000000000]
       java.lang.Thread.State: RUNNABLE
       No compile task
    
       Locked ownable synchronizers:
            - None
    
    "C1 CompilerThread0" #10 daemon prio=9 os_prio=31 cpu=610.84ms elapsed=6.96s tid=0x000000014d80ae00 nid=31235 waiting on condition  [0x0000000000000000]
       java.lang.Thread.State: RUNNABLE
       No compile task
    
       Locked ownable synchronizers:
            - None
    
    "Sweeper thread" #11 daemon prio=9 os_prio=31 cpu=17.59ms elapsed=6.96s tid=0x000000014d819600 nid=30979 runnable  [0x0000000000000000]
       java.lang.Thread.State: RUNNABLE
    
       Locked ownable synchronizers:
            - None
    
    "Common-Cleaner" #12 daemon prio=8 os_prio=31 cpu=0.50ms elapsed=6.96s tid=0x000000014d81a600 nid=30467 in Object.wait()  [0x000000016d98a000]
       java.lang.Thread.State: TIMED_WAITING (on object monitor)
            at java.lang.Object.wait(java.base@18.0.2.1/Native Method)
            - waiting on <0x00000007000014d8> (a java.lang.ref.ReferenceQueue$Lock)
            at java.lang.ref.ReferenceQueue.remove(java.base@18.0.2.1/ReferenceQueue.java:155)
            - locked <0x00000007000014d8> (a java.lang.ref.ReferenceQueue$Lock)
            at jdk.internal.ref.CleanerImpl.run(java.base@18.0.2.1/CleanerImpl.java:140)
            at java.lang.Thread.run(java.base@18.0.2.1/Thread.java:833)
            at jdk.internal.misc.InnocuousThread.run(java.base@18.0.2.1/InnocuousThread.java:162)
    
       Locked ownable synchronizers:
            - None
    
    "Monitor Ctrl-Break" #13 daemon prio=5 os_prio=31 cpu=7.63ms elapsed=6.86s tid=0x000000012c80a400 nid=30211 runnable  [0x000000016db96000]
       java.lang.Thread.State: RUNNABLE
            at sun.nio.ch.SocketDispatcher.read0(java.base@18.0.2.1/Native Method)
            at sun.nio.ch.SocketDispatcher.read(java.base@18.0.2.1/SocketDispatcher.java:47)
            at sun.nio.ch.NioSocketImpl.tryRead(java.base@18.0.2.1/NioSocketImpl.java:258)
            at sun.nio.ch.NioSocketImpl.implRead(java.base@18.0.2.1/NioSocketImpl.java:309)
            at sun.nio.ch.NioSocketImpl.read(java.base@18.0.2.1/NioSocketImpl.java:347)
            at sun.nio.ch.NioSocketImpl$1.read(java.base@18.0.2.1/NioSocketImpl.java:800)
            at java.net.Socket$SocketInputStream.read(java.base@18.0.2.1/Unknown Source)
            at sun.nio.cs.StreamDecoder.readBytes(java.base@18.0.2.1/StreamDecoder.java:270)
            at sun.nio.cs.StreamDecoder.implRead(java.base@18.0.2.1/StreamDecoder.java:313)
            at sun.nio.cs.StreamDecoder.read(java.base@18.0.2.1/StreamDecoder.java:188)
            - locked <0x0000000700002880> (a java.io.InputStreamReader)
            at java.io.InputStreamReader.read(java.base@18.0.2.1/InputStreamReader.java:176)
            at java.io.BufferedReader.fill(java.base@18.0.2.1/BufferedReader.java:162)
            at java.io.BufferedReader.readLine(java.base@18.0.2.1/BufferedReader.java:329)
            - locked <0x0000000700002880> (a java.io.InputStreamReader)
            at java.io.BufferedReader.readLine(java.base@18.0.2.1/BufferedReader.java:396)
            at com.intellij.rt.execution.application.AppMainV2$1.run(AppMainV2.java:53)
    
       Locked ownable synchronizers:
            - <0x0000000700a3ede0> (a java.util.concurrent.locks.ReentrantLock$NonfairSync)
    
    "Notification Thread" #14 daemon prio=9 os_prio=31 cpu=0.03ms elapsed=6.86s tid=0x000000014d819000 nid=25859 runnable  [0x0000000000000000]
       java.lang.Thread.State: RUNNABLE
    
       Locked ownable synchronizers:
            - None
    
    "DefaultDispatcher-worker-1" #15 daemon prio=5 os_prio=31 cpu=420.33ms elapsed=6.71s tid=0x000000013d830600 nid=28163 waiting on condition  [0x000000016ebf2000]
       java.lang.Thread.State: TIMED_WAITING (parking)
            at jdk.internal.misc.Unsafe.park(java.base@18.0.2.1/Native Method)
            at java.util.concurrent.locks.LockSupport.parkNanos(java.base@18.0.2.1/LockSupport.java:376)
            at io.ktor.utils.io.jvm.javaio.DefaultParking.park(Pollers.kt:44)
            at io.ktor.utils.io.jvm.javaio.BlockingAdapter.parkingLoop(Blocking.kt:268)
            at io.ktor.utils.io.jvm.javaio.BlockingAdapter.submitAndAwait(Blocking.kt:233)
            at io.ktor.utils.io.jvm.javaio.BlockingAdapter.submitAndAwait(Blocking.kt:201)
            at io.ktor.utils.io.jvm.javaio.OutputAdapter.write(Blocking.kt:120)
            - locked <0x0000000700cc4d38> (a io.ktor.utils.io.jvm.javaio.OutputAdapter)
            at com.fasterxml.jackson.core.json.UTF8JsonGenerator._flushBuffer(UTF8JsonGenerator.java:2208)
            at com.fasterxml.jackson.core.json.UTF8JsonGenerator._writeStringSegments(UTF8JsonGenerator.java:1348)
            at com.fasterxml.jackson.core.json.UTF8JsonGenerator.writeString(UTF8JsonGenerator.java:522)
            at com.fasterxml.jackson.databind.ser.std.StringSerializer.serialize(StringSerializer.java:41)
            at com.fasterxml.jackson.databind.ser.BeanPropertyWriter.serializeAsField(BeanPropertyWriter.java:732)
            at com.fasterxml.jackson.databind.ser.std.BeanSerializerBase.serializeFields(BeanSerializerBase.java:770)
            at com.fasterxml.jackson.databind.ser.BeanSerializer.serialize(BeanSerializer.java:183)
            at com.fasterxml.jackson.databind.ser.BeanPropertyWriter.serializeAsField(BeanPropertyWriter.java:732)
            at com.fasterxml.jackson.databind.ser.std.BeanSerializerBase.serializeFields(BeanSerializerBase.java:770)
            at com.fasterxml.jackson.databind.ser.BeanSerializer.serialize(BeanSerializer.java:183)
            at com.fasterxml.jackson.databind.ser.BeanPropertyWriter.serializeAsField(BeanPropertyWriter.java:732)
            at com.fasterxml.jackson.databind.ser.std.BeanSerializerBase.serializeFields(BeanSerializerBase.java:770)
            at com.fasterxml.jackson.databind.ser.BeanSerializer.serialize(BeanSerializer.java:183)
            at com.fasterxml.jackson.databind.ser.DefaultSerializerProvider._serialize(DefaultSerializerProvider.java:502)
            at com.fasterxml.jackson.databind.ser.DefaultSerializerProvider.serializeValue(DefaultSerializerProvider.java:341)
            at com.fasterxml.jackson.databind.ObjectMapper._writeValueAndClose(ObjectMapper.java:4793)
            at com.fasterxml.jackson.databind.ObjectMapper.writeValue(ObjectMapper.java:3997)
            at io.ktor.serialization.jackson.JacksonConverter$serializeNullable$2.invokeSuspend(JacksonConverter.kt:81)
            at io.ktor.serialization.jackson.JacksonConverter$serializeNullable$2.invoke(JacksonConverter.kt)
            at io.ktor.serialization.jackson.JacksonConverter$serializeNullable$2.invoke(JacksonConverter.kt)
            at io.ktor.http.content.OutputStreamContent$writeTo$2.invokeSuspend(OutputStreamContent.kt:28)
            at io.ktor.http.content.OutputStreamContent$writeTo$2.invoke(OutputStreamContent.kt)
            at io.ktor.http.content.OutputStreamContent$writeTo$2.invoke(OutputStreamContent.kt)
            at io.ktor.http.content.BlockingBridgeKt.withBlocking(BlockingBridge.kt:28)
            at io.ktor.http.content.OutputStreamContent.writeTo(OutputStreamContent.kt:24)
            at com.expediagroup.sdk.core.plugin.logging.RequestBodyLogger$Plugin.getBody(RequestBodyLogger.kt:53)
            at com.expediagroup.sdk.core.plugin.logging.RequestBodyLogger$Plugin.access$getBody(RequestBodyLogger.kt:33)
            at com.expediagroup.sdk.core.plugin.logging.RequestBodyLogger$Plugin$install$1.invokeSuspend(RequestBodyLogger.kt:42)
            at com.expediagroup.sdk.core.plugin.logging.RequestBodyLogger$Plugin$install$1.invoke(RequestBodyLogger.kt)
            at com.expediagroup.sdk.core.plugin.logging.RequestBodyLogger$Plugin$install$1.invoke(RequestBodyLogger.kt)
            at io.ktor.util.pipeline.SuspendFunctionGun.loop(SuspendFunctionGun.kt:120)
            at io.ktor.util.pipeline.SuspendFunctionGun.proceed(SuspendFunctionGun.kt:78)
            at io.ktor.util.pipeline.SuspendFunctionGun.proceedWith(SuspendFunctionGun.kt:88)
            at io.ktor.client.plugins.logging.Logging$setupRequestLogging$1.invokeSuspend(Logging.kt:90)
            at io.ktor.client.plugins.logging.Logging$setupRequestLogging$1.invoke(Logging.kt)
            at io.ktor.client.plugins.logging.Logging$setupRequestLogging$1.invoke(Logging.kt)
            at io.ktor.util.pipeline.SuspendFunctionGun.loop(SuspendFunctionGun.kt:120)
            at io.ktor.util.pipeline.SuspendFunctionGun.proceed(SuspendFunctionGun.kt:78)
            at io.ktor.util.pipeline.SuspendFunctionGun.execute$ktor_utils(SuspendFunctionGun.kt:98)
            at io.ktor.util.pipeline.Pipeline.execute(Pipeline.kt:77)
            at io.ktor.client.plugins.HttpSend$DefaultSender.execute(HttpSend.kt:138)
            at com.expediagroup.sdk.core.plugin.authentication.AuthenticationHookBuilder$build$1.invokeSuspend(AuthenticationHookFactory.kt:60)
            at com.expediagroup.sdk.core.plugin.authentication.AuthenticationHookBuilder$build$1.invoke(AuthenticationHookFactory.kt)
            at com.expediagroup.sdk.core.plugin.authentication.AuthenticationHookBuilder$build$1.invoke(AuthenticationHookFactory.kt)
            at io.ktor.client.plugins.HttpSend$InterceptedSender.execute(HttpSend.kt:116)
            at io.ktor.client.plugins.HttpTimeout$Plugin$install$1.invokeSuspend(HttpTimeout.kt:174)
            at io.ktor.client.plugins.HttpTimeout$Plugin$install$1.invoke(HttpTimeout.kt)
            at io.ktor.client.plugins.HttpTimeout$Plugin$install$1.invoke(HttpTimeout.kt)
            at io.ktor.client.plugins.HttpSend$InterceptedSender.execute(HttpSend.kt:116)
            at io.ktor.client.plugins.auth.Auth$Plugin$install$2.invokeSuspend(Auth.kt:67)
            at io.ktor.client.plugins.auth.Auth$Plugin$install$2.invoke(Auth.kt)
            at io.ktor.client.plugins.auth.Auth$Plugin$install$2.invoke(Auth.kt)
            at io.ktor.client.plugins.HttpSend$InterceptedSender.execute(HttpSend.kt:116)
            at io.ktor.client.plugins.HttpRedirect$Plugin$install$1.invokeSuspend(HttpRedirect.kt:64)
            at io.ktor.client.plugins.HttpRedirect$Plugin$install$1.invoke(HttpRedirect.kt)
            at io.ktor.client.plugins.HttpRedirect$Plugin$install$1.invoke(HttpRedirect.kt)
            at io.ktor.client.plugins.HttpSend$InterceptedSender.execute(HttpSend.kt:116)
            at io.ktor.client.plugins.HttpCallValidator$Companion$install$3.invokeSuspend(HttpCallValidator.kt:151)
            at io.ktor.client.plugins.HttpCallValidator$Companion$install$3.invoke(HttpCallValidator.kt)
            at io.ktor.client.plugins.HttpCallValidator$Companion$install$3.invoke(HttpCallValidator.kt)
            at io.ktor.client.plugins.HttpSend$InterceptedSender.execute(HttpSend.kt:116)
            at io.ktor.client.plugins.HttpSend$Plugin$install$1.invokeSuspend(HttpSend.kt:104)
            at io.ktor.client.plugins.HttpSend$Plugin$install$1.invoke(HttpSend.kt)
            at io.ktor.client.plugins.HttpSend$Plugin$install$1.invoke(HttpSend.kt)
            at io.ktor.util.pipeline.SuspendFunctionGun.loop(SuspendFunctionGun.kt:120)
            at io.ktor.util.pipeline.SuspendFunctionGun.proceed(SuspendFunctionGun.kt:78)
            at io.ktor.util.pipeline.SuspendFunctionGun.proceedWith(SuspendFunctionGun.kt:88)
            at io.ktor.client.plugins.DefaultTransformKt$defaultTransformers$1.invokeSuspend(DefaultTransform.kt:57)
            at io.ktor.client.plugins.DefaultTransformKt$defaultTransformers$1.invoke(DefaultTransform.kt)
            at io.ktor.client.plugins.DefaultTransformKt$defaultTransformers$1.invoke(DefaultTransform.kt)
            at io.ktor.util.pipeline.SuspendFunctionGun.loop(SuspendFunctionGun.kt:120)
            at io.ktor.util.pipeline.SuspendFunctionGun.proceed(SuspendFunctionGun.kt:78)
            at io.ktor.util.pipeline.SuspendFunctionGun.proceedWith(SuspendFunctionGun.kt:88)
            at io.ktor.client.plugins.contentnegotiation.ContentNegotiation$Plugin$install$1.invokeSuspend(ContentNegotiation.kt:252)
            at io.ktor.client.plugins.contentnegotiation.ContentNegotiation$Plugin$install$1.invoke(ContentNegotiation.kt)
            at io.ktor.client.plugins.contentnegotiation.ContentNegotiation$Plugin$install$1.invoke(ContentNegotiation.kt)
            at io.ktor.util.pipeline.SuspendFunctionGun.loop(SuspendFunctionGun.kt:120)
            at io.ktor.util.pipeline.SuspendFunctionGun.proceed(SuspendFunctionGun.kt:78)
            at io.ktor.util.pipeline.SuspendFunctionGun.proceedWith(SuspendFunctionGun.kt:88)
            at io.ktor.client.plugins.HttpCallValidator$Companion$install$1.invokeSuspend(HttpCallValidator.kt:130)
            at io.ktor.client.plugins.HttpCallValidator$Companion$install$1.invoke(HttpCallValidator.kt)
            at io.ktor.client.plugins.HttpCallValidator$Companion$install$1.invoke(HttpCallValidator.kt)
            at io.ktor.util.pipeline.SuspendFunctionGun.loop(SuspendFunctionGun.kt:120)
            at io.ktor.util.pipeline.SuspendFunctionGun.proceed(SuspendFunctionGun.kt:78)
            at io.ktor.client.plugins.HttpRequestLifecycle$Plugin$install$1.invokeSuspend(HttpRequestLifecycle.kt:38)
            at io.ktor.client.plugins.HttpRequestLifecycle$Plugin$install$1.invoke(HttpRequestLifecycle.kt)
            at io.ktor.client.plugins.HttpRequestLifecycle$Plugin$install$1.invoke(HttpRequestLifecycle.kt)
            at io.ktor.util.pipeline.SuspendFunctionGun.loop(SuspendFunctionGun.kt:120)
            at io.ktor.util.pipeline.SuspendFunctionGun.proceed(SuspendFunctionGun.kt:78)
            at io.ktor.util.pipeline.SuspendFunctionGun.execute$ktor_utils(SuspendFunctionGun.kt:98)
            at io.ktor.util.pipeline.Pipeline.execute(Pipeline.kt:77)
            at io.ktor.client.HttpClient.execute$ktor_client_core(HttpClient.kt:191)
            at io.ktor.client.statement.HttpStatement.executeUnsafe(HttpStatement.kt:108)
            at io.ktor.client.statement.HttpStatement.execute(HttpStatement.kt:47)
            at io.ktor.client.statement.HttpStatement.execute(HttpStatement.kt:62)
            at com.expediagroup.sdk.fraudpreventionv2.client.FraudPreventionV2Client$screenOrderWithResponse$1.invokeSuspend(FraudPreventionV2Client.kt:427)
            at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
            at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:104)
            at kotlinx.coroutines.internal.LimitedDispatcher$Worker.run(LimitedDispatcher.kt:111)
            at kotlinx.coroutines.scheduling.TaskImpl.run(Tasks.kt:99)
            at kotlinx.coroutines.scheduling.CoroutineScheduler.runSafely(CoroutineScheduler.kt:585)
            at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.executeTask(CoroutineScheduler.kt:802)
            at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.runWorker(CoroutineScheduler.kt:706)
            at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.run(CoroutineScheduler.kt:693)
    
       Locked ownable synchronizers:
            - None
    
    "DefaultDispatcher-worker-2" #16 daemon prio=5 os_prio=31 cpu=45.59ms elapsed=6.71s tid=0x000000014d0c7e00 nid=32771 waiting on condition  [0x000000016ee02000]
       java.lang.Thread.State: TIMED_WAITING (parking)
            at jdk.internal.misc.Unsafe.park(java.base@18.0.2.1/Native Method)
            at java.util.concurrent.locks.LockSupport.parkNanos(java.base@18.0.2.1/LockSupport.java:376)
            at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.park(CoroutineScheduler.kt:847)
            at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.tryPark(CoroutineScheduler.kt:792)
            at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.runWorker(CoroutineScheduler.kt:740)
            at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.run(CoroutineScheduler.kt:693)
    
       Locked ownable synchronizers:
            - None
    
    "DefaultDispatcher-worker-3" #17 daemon prio=5 os_prio=31 cpu=112.48ms elapsed=6.71s tid=0x000000012c80aa00 nid=43011 waiting on condition  [0x000000016f00e000]
       java.lang.Thread.State: TIMED_WAITING (parking)
            at jdk.internal.misc.Unsafe.park(java.base@18.0.2.1/Native Method)
            at java.util.concurrent.locks.LockSupport.parkNanos(java.base@18.0.2.1/LockSupport.java:376)
            at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.park(CoroutineScheduler.kt:847)
            at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.tryPark(CoroutineScheduler.kt:792)
            at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.runWorker(CoroutineScheduler.kt:740)
            at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.run(CoroutineScheduler.kt:693)
    
       Locked ownable synchronizers:
            - None
    
    "kotlinx.coroutines.DefaultExecutor" #19 daemon prio=5 os_prio=31 cpu=0.26ms elapsed=6.23s tid=0x000000012c8d9e00 nid=42243 waiting on condition  [0x000000016f426000]
       java.lang.Thread.State: TIMED_WAITING (parking)
            at jdk.internal.misc.Unsafe.park(java.base@18.0.2.1/Native Method)
            - parking to wait for  <0x0000000700074368> (a kotlinx.coroutines.DefaultExecutor)
            at java.util.concurrent.locks.LockSupport.parkNanos(java.base@18.0.2.1/LockSupport.java:252)
            at kotlinx.coroutines.DefaultExecutor.run(DefaultExecutor.kt:118)
            at java.lang.Thread.run(java.base@18.0.2.1/Thread.java:833)
    
       Locked ownable synchronizers:
            - None
    
    "OkHttp Dispatcher" #20 prio=5 os_prio=31 cpu=85.83ms elapsed=6.10s tid=0x000000012d185400 nid=34051 waiting on condition  [0x000000016fc56000]
       java.lang.Thread.State: TIMED_WAITING (parking)
            at jdk.internal.misc.Unsafe.park(java.base@18.0.2.1/Native Method)
            - parking to wait for  <0x000000070074ac30> (a java.util.concurrent.SynchronousQueue$TransferStack)
            at java.util.concurrent.locks.LockSupport.parkNanos(java.base@18.0.2.1/LockSupport.java:252)
            at java.util.concurrent.SynchronousQueue$TransferStack.transfer(java.base@18.0.2.1/SynchronousQueue.java:401)
            at java.util.concurrent.SynchronousQueue.poll(java.base@18.0.2.1/SynchronousQueue.java:903)
            at java.util.concurrent.ThreadPoolExecutor.getTask(java.base@18.0.2.1/ThreadPoolExecutor.java:1061)
            at java.util.concurrent.ThreadPoolExecutor.runWorker(java.base@18.0.2.1/ThreadPoolExecutor.java:1122)
            at java.util.concurrent.ThreadPoolExecutor$Worker.run(java.base@18.0.2.1/ThreadPoolExecutor.java:635)
            at java.lang.Thread.run(java.base@18.0.2.1/Thread.java:833)
    
       Locked ownable synchronizers:
            - None
    
    "OkHttp TaskRunner" #21 daemon prio=5 os_prio=31 cpu=0.20ms elapsed=5.58s tid=0x000000013d0b4a00 nid=40707 in Object.wait()  [0x000000016fe62000]
       java.lang.Thread.State: TIMED_WAITING (on object monitor)
            at java.lang.Object.wait(java.base@18.0.2.1/Native Method)
            - waiting on <0x0000000700715ba8> (a okhttp3.internal.concurrent.TaskRunner)
            at java.lang.Object.wait(java.base@18.0.2.1/Object.java:472)
            at okhttp3.internal.concurrent.TaskRunner$RealBackend.coordinatorWait(TaskRunner.kt:294)
            at okhttp3.internal.concurrent.TaskRunner.awaitTaskToRun(TaskRunner.kt:218)
            at okhttp3.internal.concurrent.TaskRunner$runnable$1.run(TaskRunner.kt:59)
            - locked <0x0000000700715ba8> (a okhttp3.internal.concurrent.TaskRunner)
            at java.util.concurrent.ThreadPoolExecutor.runWorker(java.base@18.0.2.1/ThreadPoolExecutor.java:1136)
            at java.util.concurrent.ThreadPoolExecutor$Worker.run(java.base@18.0.2.1/ThreadPoolExecutor.java:635)
            at java.lang.Thread.run(java.base@18.0.2.1/Thread.java:833)
    
       Locked ownable synchronizers:
            - <0x0000000700715e58> (a java.util.concurrent.ThreadPoolExecutor$Worker)
    
    "Okio Watchdog" #22 daemon prio=5 os_prio=31 cpu=0.17ms elapsed=5.57s tid=0x000000014d0dca00 nid=40451 waiting on condition  [0x0000000320206000]
       java.lang.Thread.State: TIMED_WAITING (parking)
            at jdk.internal.misc.Unsafe.park(java.base@18.0.2.1/Native Method)
            - parking to wait for  <0x0000000700765590> (a java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject)
            at java.util.concurrent.locks.LockSupport.parkNanos(java.base@18.0.2.1/LockSupport.java:252)
            at java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject.await(java.base@18.0.2.1/AbstractQueuedSynchronizer.java:1757)
            at okio.AsyncTimeout$Companion.awaitTimeout(AsyncTimeout.kt:370)
            at okio.AsyncTimeout$Watchdog.run(AsyncTimeout.kt:211)
    
       Locked ownable synchronizers:
            - None
    
    "DefaultDispatcher-worker-4" #23 daemon prio=5 os_prio=31 cpu=0.07ms elapsed=4.40s tid=0x000000013d11e400 nid=40195 waiting on condition  [0x0000000320412000]
       java.lang.Thread.State: TIMED_WAITING (parking)
            at jdk.internal.misc.Unsafe.park(java.base@18.0.2.1/Native Method)
            at java.util.concurrent.locks.LockSupport.parkNanos(java.base@18.0.2.1/LockSupport.java:376)
            at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.park(CoroutineScheduler.kt:847)
            at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.tryPark(CoroutineScheduler.kt:792)
            at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.runWorker(CoroutineScheduler.kt:740)
            at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.run(CoroutineScheduler.kt:693)
    
       Locked ownable synchronizers:
            - None
    
    "DefaultDispatcher-worker-5" #24 daemon prio=5 os_prio=31 cpu=0.06ms elapsed=4.40s tid=0x000000013d11ea00 nid=39683 waiting on condition  [0x000000032061e000]
       java.lang.Thread.State: TIMED_WAITING (parking)
            at jdk.internal.misc.Unsafe.park(java.base@18.0.2.1/Native Method)
            at java.util.concurrent.locks.LockSupport.parkNanos(java.base@18.0.2.1/LockSupport.java:376)
            at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.park(CoroutineScheduler.kt:847)
            at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.tryPark(CoroutineScheduler.kt:792)
            at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.runWorker(CoroutineScheduler.kt:740)
            at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.run(CoroutineScheduler.kt:693)
    
       Locked ownable synchronizers:
            - None
    
    "Attach Listener" #25 daemon prio=9 os_prio=31 cpu=166.51ms elapsed=3.45s tid=0x000000013e825400 nid=39171 waiting on condition  [0x0000000000000000]
       java.lang.Thread.State: RUNNABLE
    
       Locked ownable synchronizers:
            - None
    
    "JFR Recorder Thread" #26 daemon prio=5 os_prio=31 cpu=0.10ms elapsed=3.33s tid=0x000000012f846000 nid=35331 runnable  [0x0000000000000000]
       java.lang.Thread.State: RUNNABLE
    
       Locked ownable synchronizers:
            - None
    
    "JFR Periodic Tasks" #27 daemon prio=9 os_prio=31 cpu=14.11ms elapsed=3.23s tid=0x000000014d9c9c00 nid=38659 in Object.wait()  [0x0000000320c42000]
       java.lang.Thread.State: TIMED_WAITING (on object monitor)
            at java.lang.Object.wait(java.base@18.0.2.1/Native Method)
            - waiting on <no object reference available>
            at jdk.jfr.internal.PlatformRecorder.takeNap(jdk.jfr@18.0.2.1/PlatformRecorder.java:526)
            - locked <0x0000000700cd9ba0> (a java.lang.Object)
            at jdk.jfr.internal.PlatformRecorder.periodicTask(jdk.jfr@18.0.2.1/PlatformRecorder.java:507)
            at jdk.jfr.internal.PlatformRecorder.lambda$startDiskMonitor$1(jdk.jfr@18.0.2.1/PlatformRecorder.java:447)
            at jdk.jfr.internal.PlatformRecorder$$Lambda$188/0x0000000800ec31c0.run(jdk.jfr@18.0.2.1/Unknown Source)
            at java.lang.Thread.run(java.base@18.0.2.1/Thread.java:833)
    
       Locked ownable synchronizers:
            - None
    
    "RMI TCP Accept-0" #29 daemon prio=9 os_prio=31 cpu=3.54ms elapsed=2.71s tid=0x000000012c8cd600 nid=35587 runnable  [0x0000000320e4e000]
       java.lang.Thread.State: RUNNABLE
            at sun.nio.ch.Net.accept(java.base@18.0.2.1/Native Method)
            at sun.nio.ch.NioSocketImpl.accept(java.base@18.0.2.1/NioSocketImpl.java:752)
            at java.net.ServerSocket.implAccept(java.base@18.0.2.1/ServerSocket.java:673)
            at java.net.ServerSocket.platformImplAccept(java.base@18.0.2.1/ServerSocket.java:639)
            at java.net.ServerSocket.implAccept(java.base@18.0.2.1/ServerSocket.java:615)
            at java.net.ServerSocket.implAccept(java.base@18.0.2.1/ServerSocket.java:572)
            at java.net.ServerSocket.accept(java.base@18.0.2.1/ServerSocket.java:530)
            at sun.management.jmxremote.LocalRMIServerSocketFactory$1.accept(jdk.management.agent@18.0.2.1/LocalRMIServerSocketFactory.java:52)
            at sun.rmi.transport.tcp.TCPTransport$AcceptLoop.executeAcceptLoop(java.rmi@18.0.2.1/TCPTransport.java:424)
            at sun.rmi.transport.tcp.TCPTransport$AcceptLoop.run(java.rmi@18.0.2.1/TCPTransport.java:388)
            at java.lang.Thread.run(java.base@18.0.2.1/Thread.java:833)
    
       Locked ownable synchronizers:
            - <0x000000070ffc81a8> (a java.util.concurrent.locks.ReentrantLock$NonfairSync)
    
    "RMI TCP Connection(1)-192.168.0.104" #30 daemon prio=9 os_prio=31 cpu=46.20ms elapsed=2.69s tid=0x000000013d83ae00 nid=37891 runnable  [0x0000000321059000]
       java.lang.Thread.State: RUNNABLE
            at sun.nio.ch.Net.poll(java.base@18.0.2.1/Native Method)
            at sun.nio.ch.NioSocketImpl.park(java.base@18.0.2.1/NioSocketImpl.java:178)
            at sun.nio.ch.NioSocketImpl.timedRead(java.base@18.0.2.1/NioSocketImpl.java:282)
            at sun.nio.ch.NioSocketImpl.implRead(java.base@18.0.2.1/NioSocketImpl.java:306)
            at sun.nio.ch.NioSocketImpl.read(java.base@18.0.2.1/NioSocketImpl.java:347)
            at sun.nio.ch.NioSocketImpl$1.read(java.base@18.0.2.1/NioSocketImpl.java:800)
            at java.net.Socket$SocketInputStream.read(java.base@18.0.2.1/Socket.java:966)
            at java.io.BufferedInputStream.fill(java.base@18.0.2.1/BufferedInputStream.java:244)
            at java.io.BufferedInputStream.read(java.base@18.0.2.1/BufferedInputStream.java:263)
            - locked <0x000000070de38c88> (a java.io.BufferedInputStream)
            at java.io.FilterInputStream.read(java.base@18.0.2.1/FilterInputStream.java:79)
            at sun.rmi.transport.tcp.TCPTransport.handleMessages(java.rmi@18.0.2.1/TCPTransport.java:580)
            at sun.rmi.transport.tcp.TCPTransport$ConnectionHandler.run0(java.rmi@18.0.2.1/TCPTransport.java:844)
            at sun.rmi.transport.tcp.TCPTransport$ConnectionHandler.lambda$run$0(java.rmi@18.0.2.1/TCPTransport.java:721)
            at sun.rmi.transport.tcp.TCPTransport$ConnectionHandler$$Lambda$243/0x000000080102cf88.run(java.rmi@18.0.2.1/Unknown Source)
            at java.security.AccessController.executePrivileged(java.base@18.0.2.1/AccessController.java:776)
            at java.security.AccessController.doPrivileged(java.base@18.0.2.1/AccessController.java:399)
            at sun.rmi.transport.tcp.TCPTransport$ConnectionHandler.run(java.rmi@18.0.2.1/TCPTransport.java:720)
            at java.util.concurrent.ThreadPoolExecutor.runWorker(java.base@18.0.2.1/ThreadPoolExecutor.java:1136)
            at java.util.concurrent.ThreadPoolExecutor$Worker.run(java.base@18.0.2.1/ThreadPoolExecutor.java:635)
            at java.lang.Thread.run(java.base@18.0.2.1/Thread.java:833)
    
       Locked ownable synchronizers:
            - <0x000000070ffccd60> (a java.util.concurrent.locks.ReentrantLock$NonfairSync)
            - <0x000000070ffd1758> (a java.util.concurrent.ThreadPoolExecutor$Worker)
    
    "RMI Scheduler(0)" #31 daemon prio=9 os_prio=31 cpu=0.17ms elapsed=2.68s tid=0x000000014d8eca00 nid=37635 waiting on condition  [0x0000000321266000]
       java.lang.Thread.State: TIMED_WAITING (parking)
            at jdk.internal.misc.Unsafe.park(java.base@18.0.2.1/Native Method)
            - parking to wait for  <0x000000070ffc1898> (a java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject)
            at java.util.concurrent.locks.LockSupport.parkNanos(java.base@18.0.2.1/LockSupport.java:252)
            at java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject.awaitNanos(java.base@18.0.2.1/AbstractQueuedSynchronizer.java:1672)
            at java.util.concurrent.ScheduledThreadPoolExecutor$DelayedWorkQueue.take(java.base@18.0.2.1/ScheduledThreadPoolExecutor.java:1182)
            at java.util.concurrent.ScheduledThreadPoolExecutor$DelayedWorkQueue.take(java.base@18.0.2.1/ScheduledThreadPoolExecutor.java:899)
            at java.util.concurrent.ThreadPoolExecutor.getTask(java.base@18.0.2.1/ThreadPoolExecutor.java:1062)
            at java.util.concurrent.ThreadPoolExecutor.runWorker(java.base@18.0.2.1/ThreadPoolExecutor.java:1122)
            at java.util.concurrent.ThreadPoolExecutor$Worker.run(java.base@18.0.2.1/ThreadPoolExecutor.java:635)
            at java.lang.Thread.run(java.base@18.0.2.1/Thread.java:833)
    
       Locked ownable synchronizers:
            - None
    
    "JMX server connection timeout 32" #32 daemon prio=9 os_prio=31 cpu=1.78ms elapsed=2.67s tid=0x000000014e825600 nid=36611 in Object.wait()  [0x0000000321472000]
       java.lang.Thread.State: TIMED_WAITING (on object monitor)
            at java.lang.Object.wait(java.base@18.0.2.1/Native Method)
            - waiting on <no object reference available>
            at com.sun.jmx.remote.internal.ServerCommunicatorAdmin$Timeout.run(java.management@18.0.2.1/ServerCommunicatorAdmin.java:171)
            - locked <0x000000070de84cc0> (a [I)
            at java.lang.Thread.run(java.base@18.0.2.1/Thread.java:833)
    
       Locked ownable synchronizers:
            - None
    
    "RMI TCP Connection(2)-192.168.0.104" #33 daemon prio=9 os_prio=31 cpu=10.54ms elapsed=1.62s tid=0x000000012c8ce200 nid=23303 runnable  [0x000000032167d000]
       java.lang.Thread.State: RUNNABLE
            at sun.nio.ch.Net.poll(java.base@18.0.2.1/Native Method)
            at sun.nio.ch.NioSocketImpl.park(java.base@18.0.2.1/NioSocketImpl.java:178)
            at sun.nio.ch.NioSocketImpl.timedRead(java.base@18.0.2.1/NioSocketImpl.java:282)
            at sun.nio.ch.NioSocketImpl.implRead(java.base@18.0.2.1/NioSocketImpl.java:306)
            at sun.nio.ch.NioSocketImpl.read(java.base@18.0.2.1/NioSocketImpl.java:347)
            at sun.nio.ch.NioSocketImpl$1.read(java.base@18.0.2.1/NioSocketImpl.java:800)
            at java.net.Socket$SocketInputStream.read(java.base@18.0.2.1/Socket.java:966)
            at java.io.BufferedInputStream.fill(java.base@18.0.2.1/BufferedInputStream.java:244)
            at java.io.BufferedInputStream.read(java.base@18.0.2.1/BufferedInputStream.java:263)
            - locked <0x000000070dd300b0> (a java.io.BufferedInputStream)
            at java.io.FilterInputStream.read(java.base@18.0.2.1/FilterInputStream.java:79)
            at sun.rmi.transport.tcp.TCPTransport.handleMessages(java.rmi@18.0.2.1/TCPTransport.java:580)
            at sun.rmi.transport.tcp.TCPTransport$ConnectionHandler.run0(java.rmi@18.0.2.1/TCPTransport.java:844)
            at sun.rmi.transport.tcp.TCPTransport$ConnectionHandler.lambda$run$0(java.rmi@18.0.2.1/TCPTransport.java:721)
            at sun.rmi.transport.tcp.TCPTransport$ConnectionHandler$$Lambda$243/0x000000080102cf88.run(java.rmi@18.0.2.1/Unknown Source)
            at java.security.AccessController.executePrivileged(java.base@18.0.2.1/AccessController.java:776)
            at java.security.AccessController.doPrivileged(java.base@18.0.2.1/AccessController.java:399)
            at sun.rmi.transport.tcp.TCPTransport$ConnectionHandler.run(java.rmi@18.0.2.1/TCPTransport.java:720)
            at java.util.concurrent.ThreadPoolExecutor.runWorker(java.base@18.0.2.1/ThreadPoolExecutor.java:1136)
            at java.util.concurrent.ThreadPoolExecutor$Worker.run(java.base@18.0.2.1/ThreadPoolExecutor.java:635)
            at java.lang.Thread.run(java.base@18.0.2.1/Thread.java:833)
    
       Locked ownable synchronizers:
            - <0x000000070ffd1af8> (a java.util.concurrent.locks.ReentrantLock$NonfairSync)
            - <0x000000070ffd2fc0> (a java.util.concurrent.ThreadPoolExecutor$Worker)
    
    "VM Thread" os_prio=31 cpu=26.91ms elapsed=6.97s tid=0x000000013cf04390 nid=18947 runnable
    
    "GC Thread#0" os_prio=31 cpu=12.83ms elapsed=6.98s tid=0x000000013e105c00 nid=12547 runnable
    
    "GC Thread#1" os_prio=31 cpu=10.59ms elapsed=6.73s tid=0x000000013ce16350 nid=29187 runnable
    
    "GC Thread#2" os_prio=31 cpu=8.94ms elapsed=6.73s tid=0x000000013ce167c0 nid=26627 runnable
    
    "GC Thread#3" os_prio=31 cpu=6.91ms elapsed=6.73s tid=0x000000013ce16c30 nid=26883 runnable
    
    "GC Thread#4" os_prio=31 cpu=12.26ms elapsed=6.73s tid=0x000000013ce170a0 nid=28675 runnable
    
    "GC Thread#5" os_prio=31 cpu=9.08ms elapsed=6.73s tid=0x000000013ce17510 nid=28419 runnable
    
    "GC Thread#6" os_prio=31 cpu=6.05ms elapsed=6.42s tid=0x000000013ce29b70 nid=33027 runnable
    
    "GC Thread#7" os_prio=31 cpu=4.47ms elapsed=6.22s tid=0x000000013ce3b360 nid=41987 runnable
    
    "GC Thread#8" os_prio=31 cpu=3.02ms elapsed=6.22s tid=0x0000000105415e10 nid=33539 runnable
    
    "G1 Main Marker" os_prio=31 cpu=0.27ms elapsed=6.98s tid=0x000000014ce05f90 nid=13827 runnable
    
    "G1 Conc#0" os_prio=31 cpu=13.09ms elapsed=6.98s tid=0x000000014ce06800 nid=13059 runnable
    
    "G1 Conc#1" os_prio=31 cpu=13.21ms elapsed=6.22s tid=0x000000014e033be0 nid=41219 runnable
    
    "G1 Refine#0" os_prio=31 cpu=0.05ms elapsed=6.98s tid=0x000000014ce13920 nid=21507 runnable
    
    "G1 Service" os_prio=31 cpu=1.00ms elapsed=6.98s tid=0x000000013ce045b0 nid=20995 runnable
    
    "VM Periodic Task Thread" os_prio=31 cpu=1.99ms elapsed=6.86s tid=0x000000014e00aae0 nid=29443 waiting on condition
</details>

## Task
Based on the observable threads state, and as shown before, we need to find a way to unlock the waiting state of threads. Also, if applicable, it would be better to eliminate the manual management of `ByteChannel` instances.

## Action
Since it would be better not to manage any data streaming channels manually, we have updated the implementation such that any manual management of data streaming channels is eliminated. 

The mentioned changes were achieved by running any write and read operations seeking the read of the `body` element and transforming it into a `String`, inside a new [`coroutineScope`](https://kotlinlang.org/api/kotlinx.coroutines/kotlinx-coroutines-core/kotlinx.coroutines/coroutine-scope.html), then a [`WriterJob`](https://api.ktor.io/ktor-io/io.ktor.utils.io/-writer-job/index.html) is used to handle the body transformation operations. 

The `coroutineScope` will ensure that the running or created coroutine, including any of its children, will have an automatic management of coroutine lifecycle.

```kotlin
return coroutineScope {
    writer {
        body.writeTo(channel)
    }.channel.readRemaining().readText()
}
```

## Results
The application state is now stable, and the threads state are no longer in an indefinite waiting state, resembling what looks like a deadlock state. Please check the following threads dump:

<details>
<summary><b>Threads Dump</b></summary>

    2024-04-02 21:12:02
    Full thread dump OpenJDK 64-Bit Server VM (18.0.2.1+1-1 mixed mode, sharing):
    
    Threads class SMR info:
    _java_thread_list=0x00006000013a10c0, length=36, elements={
    0x0000000100808200, 0x000000012400e400, 0x000000012400ea00, 0x0000000124808200,
    0x0000000125067a00, 0x0000000125068000, 0x000000012401fc00, 0x0000000124020200,
    0x0000000124020800, 0x0000000124020e00, 0x0000000124062400, 0x0000000124024400,
    0x0000000125069c00, 0x00000001250da400, 0x0000000123067800, 0x0000000107808200,
    0x0000000124099e00, 0x0000000125cc0a00, 0x00000001250ec200, 0x00000001008eb800,
    0x00000001008b6e00, 0x0000000100a8de00, 0x0000000107065800, 0x0000000123260400,
    0x000000010302ee00, 0x0000000103019200, 0x00000001250eba00, 0x0000000123071400,
    0x0000000100808800, 0x0000000123079a00, 0x0000000107838a00, 0x0000000100a84000,
    0x0000000107015c00, 0x0000000107837a00, 0x0000000107838000, 0x0000000107839000
    }
    
    "main" #1 prio=5 os_prio=31 cpu=401.48ms elapsed=7.50s tid=0x0000000100808200 nid=10243 waiting on condition  [0x000000017004a000]
       java.lang.Thread.State: WAITING (parking)
            at jdk.internal.misc.Unsafe.park(java.base@18.0.2.1/Native Method)
            - parking to wait for  <0x0000000702000000> (a java.util.concurrent.CompletableFuture$Signaller)
            at java.util.concurrent.locks.LockSupport.park(java.base@18.0.2.1/LockSupport.java:211)
            at java.util.concurrent.CompletableFuture$Signaller.block(java.base@18.0.2.1/CompletableFuture.java:1864)
            at java.util.concurrent.ForkJoinPool.unmanagedBlock(java.base@18.0.2.1/ForkJoinPool.java:3464)
            at java.util.concurrent.ForkJoinPool.managedBlock(java.base@18.0.2.1/ForkJoinPool.java:3435)
            at java.util.concurrent.CompletableFuture.waitingGet(java.base@18.0.2.1/CompletableFuture.java:1898)
            at java.util.concurrent.CompletableFuture.get(java.base@18.0.2.1/CompletableFuture.java:2072)
            at com.expediagroup.sdk.fraudpreventionv2.client.FraudPreventionV2Client.screenOrderWithResponse(FraudPreventionV2Client.kt:408)
            at com.expediagroup.sdk.fraudpreventionv2.client.FraudPreventionV2Client.screenOrder(FraudPreventionV2Client.kt:374)
            at org.jarrah.Main.main(Main.java:33)
    
       Locked ownable synchronizers:
            - None
    
    "Reference Handler" #2 daemon prio=10 os_prio=31 cpu=0.55ms elapsed=7.48s tid=0x000000012400e400 nid=18435 waiting on condition  [0x0000000170e9e000]
       java.lang.Thread.State: RUNNABLE
            at java.lang.ref.Reference.waitForReferencePendingList(java.base@18.0.2.1/Native Method)
            at java.lang.ref.Reference.processPendingReferences(java.base@18.0.2.1/Reference.java:253)
            at java.lang.ref.Reference$ReferenceHandler.run(java.base@18.0.2.1/Reference.java:215)
    
       Locked ownable synchronizers:
            - None
    
    "Finalizer" #3 daemon prio=8 os_prio=31 cpu=0.08ms elapsed=7.48s tid=0x000000012400ea00 nid=18947 in Object.wait()  [0x00000001710aa000]
       java.lang.Thread.State: WAITING (on object monitor)
            at java.lang.Object.wait(java.base@18.0.2.1/Native Method)
            - waiting on <0x0000000700008cd0> (a java.lang.ref.ReferenceQueue$Lock)
            at java.lang.ref.ReferenceQueue.remove(java.base@18.0.2.1/ReferenceQueue.java:155)
            - locked <0x0000000700008cd0> (a java.lang.ref.ReferenceQueue$Lock)
            at java.lang.ref.ReferenceQueue.remove(java.base@18.0.2.1/ReferenceQueue.java:176)
            at java.lang.ref.Finalizer$FinalizerThread.run(java.base@18.0.2.1/Finalizer.java:183)
    
       Locked ownable synchronizers:
            - None
    
    "Signal Dispatcher" #4 daemon prio=9 os_prio=31 cpu=0.17ms elapsed=7.47s tid=0x0000000124808200 nid=31491 waiting on condition  [0x0000000000000000]
       java.lang.Thread.State: RUNNABLE
    
       Locked ownable synchronizers:
            - None
    
    "Service Thread" #5 daemon prio=9 os_prio=31 cpu=0.19ms elapsed=7.47s tid=0x0000000125067a00 nid=30979 runnable  [0x0000000000000000]
       java.lang.Thread.State: RUNNABLE
    
       Locked ownable synchronizers:
            - None
    
    "Monitor Deflation Thread" #6 daemon prio=9 os_prio=31 cpu=0.11ms elapsed=7.47s tid=0x0000000125068000 nid=30723 runnable  [0x0000000000000000]
       java.lang.Thread.State: RUNNABLE
    
       Locked ownable synchronizers:
            - None
    
    "C2 CompilerThread0" #7 daemon prio=9 os_prio=31 cpu=1849.02ms elapsed=7.47s tid=0x000000012401fc00 nid=24067 waiting on condition  [0x0000000000000000]
       java.lang.Thread.State: RUNNABLE
       No compile task
    
       Locked ownable synchronizers:
            - None
    
    "C1 CompilerThread0" #10 daemon prio=9 os_prio=31 cpu=861.32ms elapsed=7.47s tid=0x0000000124020200 nid=24579 waiting on condition  [0x0000000000000000]
       java.lang.Thread.State: RUNNABLE
       No compile task
    
       Locked ownable synchronizers:
            - None
    
    "Sweeper thread" #11 daemon prio=9 os_prio=31 cpu=19.02ms elapsed=7.47s tid=0x0000000124020800 nid=30211 runnable  [0x0000000000000000]
       java.lang.Thread.State: RUNNABLE
    
       Locked ownable synchronizers:
            - None
    
    "Common-Cleaner" #12 daemon prio=8 os_prio=31 cpu=0.64ms elapsed=7.45s tid=0x0000000124020e00 nid=29955 in Object.wait()  [0x0000000172016000]
       java.lang.Thread.State: TIMED_WAITING (on object monitor)
            at java.lang.Object.wait(java.base@18.0.2.1/Native Method)
            - waiting on <0x0000000700001308> (a java.lang.ref.ReferenceQueue$Lock)
            at java.lang.ref.ReferenceQueue.remove(java.base@18.0.2.1/ReferenceQueue.java:155)
            - locked <0x0000000700001308> (a java.lang.ref.ReferenceQueue$Lock)
            at jdk.internal.ref.CleanerImpl.run(java.base@18.0.2.1/CleanerImpl.java:140)
            at java.lang.Thread.run(java.base@18.0.2.1/Thread.java:833)
            at jdk.internal.misc.InnocuousThread.run(java.base@18.0.2.1/InnocuousThread.java:162)
    
       Locked ownable synchronizers:
            - None
    
    "Monitor Ctrl-Break" #13 daemon prio=5 os_prio=31 cpu=8.84ms elapsed=7.36s tid=0x0000000124062400 nid=29443 runnable  [0x0000000172222000]
       java.lang.Thread.State: RUNNABLE
            at sun.nio.ch.SocketDispatcher.read0(java.base@18.0.2.1/Native Method)
            at sun.nio.ch.SocketDispatcher.read(java.base@18.0.2.1/SocketDispatcher.java:47)
            at sun.nio.ch.NioSocketImpl.tryRead(java.base@18.0.2.1/NioSocketImpl.java:258)
            at sun.nio.ch.NioSocketImpl.implRead(java.base@18.0.2.1/NioSocketImpl.java:309)
            at sun.nio.ch.NioSocketImpl.read(java.base@18.0.2.1/NioSocketImpl.java:347)
            at sun.nio.ch.NioSocketImpl$1.read(java.base@18.0.2.1/NioSocketImpl.java:800)
            at java.net.Socket$SocketInputStream.read(java.base@18.0.2.1/Unknown Source)
            at sun.nio.cs.StreamDecoder.readBytes(java.base@18.0.2.1/StreamDecoder.java:270)
            at sun.nio.cs.StreamDecoder.implRead(java.base@18.0.2.1/StreamDecoder.java:313)
            at sun.nio.cs.StreamDecoder.read(java.base@18.0.2.1/StreamDecoder.java:188)
            - locked <0x0000000700000fc0> (a java.io.InputStreamReader)
            at java.io.InputStreamReader.read(java.base@18.0.2.1/InputStreamReader.java:176)
            at java.io.BufferedReader.fill(java.base@18.0.2.1/BufferedReader.java:162)
            at java.io.BufferedReader.readLine(java.base@18.0.2.1/BufferedReader.java:329)
            - locked <0x0000000700000fc0> (a java.io.InputStreamReader)
            at java.io.BufferedReader.readLine(java.base@18.0.2.1/BufferedReader.java:396)
            at com.intellij.rt.execution.application.AppMainV2$1.run(AppMainV2.java:53)
    
       Locked ownable synchronizers:
            - <0x00000007008f5ff0> (a java.util.concurrent.locks.ReentrantLock$NonfairSync)
    
    "Notification Thread" #14 daemon prio=9 os_prio=31 cpu=0.02ms elapsed=7.36s tid=0x0000000124024400 nid=28931 runnable  [0x0000000000000000]
       java.lang.Thread.State: RUNNABLE
    
       Locked ownable synchronizers:
            - None
    
    "DefaultDispatcher-worker-1" #15 daemon prio=5 os_prio=31 cpu=601.02ms elapsed=7.16s tid=0x0000000125069c00 nid=26883 waiting on condition  [0x0000000173282000]
       java.lang.Thread.State: TIMED_WAITING (parking)
            at jdk.internal.misc.Unsafe.park(java.base@18.0.2.1/Native Method)
            at java.util.concurrent.locks.LockSupport.parkNanos(java.base@18.0.2.1/LockSupport.java:376)
            at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.park(CoroutineScheduler.kt:847)
            at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.tryPark(CoroutineScheduler.kt:792)
            at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.runWorker(CoroutineScheduler.kt:740)
            at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.run(CoroutineScheduler.kt:693)
    
       Locked ownable synchronizers:
            - None
    
    "DefaultDispatcher-worker-2" #16 daemon prio=5 os_prio=31 cpu=432.07ms elapsed=7.16s tid=0x00000001250da400 nid=32771 waiting on condition  [0x000000017348e000]
       java.lang.Thread.State: TIMED_WAITING (parking)
            at jdk.internal.misc.Unsafe.park(java.base@18.0.2.1/Native Method)
            at java.util.concurrent.locks.LockSupport.parkNanos(java.base@18.0.2.1/LockSupport.java:376)
            at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.park(CoroutineScheduler.kt:847)
            at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.tryPark(CoroutineScheduler.kt:792)
            at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.runWorker(CoroutineScheduler.kt:740)
            at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.run(CoroutineScheduler.kt:693)
    
       Locked ownable synchronizers:
            - None
    
    "DefaultDispatcher-worker-3" #17 daemon prio=5 os_prio=31 cpu=58.43ms elapsed=7.16s tid=0x0000000123067800 nid=43267 waiting on condition  [0x000000017369a000]
       java.lang.Thread.State: TIMED_WAITING (parking)
            at jdk.internal.misc.Unsafe.park(java.base@18.0.2.1/Native Method)
            at java.util.concurrent.locks.LockSupport.parkNanos(java.base@18.0.2.1/LockSupport.java:376)
            at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.park(CoroutineScheduler.kt:847)
            at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.tryPark(CoroutineScheduler.kt:792)
            at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.runWorker(CoroutineScheduler.kt:740)
            at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.run(CoroutineScheduler.kt:693)
    
       Locked ownable synchronizers:
            - None
    
    "kotlinx.coroutines.DefaultExecutor" #19 daemon prio=5 os_prio=31 cpu=0.18ms elapsed=6.54s tid=0x0000000107808200 nid=33795 waiting on condition  [0x0000000173ab2000]
       java.lang.Thread.State: TIMED_WAITING (parking)
            at jdk.internal.misc.Unsafe.park(java.base@18.0.2.1/Native Method)
            - parking to wait for  <0x00000007000080d0> (a kotlinx.coroutines.DefaultExecutor)
            at java.util.concurrent.locks.LockSupport.parkNanos(java.base@18.0.2.1/LockSupport.java:252)
            at kotlinx.coroutines.DefaultExecutor.run(DefaultExecutor.kt:118)
            at java.lang.Thread.run(java.base@18.0.2.1/Thread.java:833)
    
       Locked ownable synchronizers:
            - None
    
    "OkHttp https://api.expediagroup.com/..." #20 prio=5 os_prio=31 cpu=115.97ms elapsed=6.26s tid=0x0000000124099e00 nid=34819 runnable  [0x00000001742e1000]
       java.lang.Thread.State: RUNNABLE
            at sun.nio.ch.Net.poll(java.base@18.0.2.1/Native Method)
            at sun.nio.ch.NioSocketImpl.park(java.base@18.0.2.1/NioSocketImpl.java:178)
            at sun.nio.ch.NioSocketImpl.timedRead(java.base@18.0.2.1/NioSocketImpl.java:282)
            at sun.nio.ch.NioSocketImpl.implRead(java.base@18.0.2.1/NioSocketImpl.java:306)
            at sun.nio.ch.NioSocketImpl.read(java.base@18.0.2.1/NioSocketImpl.java:347)
            at sun.nio.ch.NioSocketImpl$1.read(java.base@18.0.2.1/NioSocketImpl.java:800)
            at java.net.Socket$SocketInputStream.read(java.base@18.0.2.1/Socket.java:966)
            at sun.security.ssl.SSLSocketInputRecord.read(java.base@18.0.2.1/SSLSocketInputRecord.java:478)
            at sun.security.ssl.SSLSocketInputRecord.readHeader(java.base@18.0.2.1/SSLSocketInputRecord.java:472)
            at sun.security.ssl.SSLSocketInputRecord.bytesInCompletePacket(java.base@18.0.2.1/SSLSocketInputRecord.java:70)
            at sun.security.ssl.SSLSocketImpl.readApplicationRecord(java.base@18.0.2.1/SSLSocketImpl.java:1460)
            at sun.security.ssl.SSLSocketImpl$AppInputStream.read(java.base@18.0.2.1/SSLSocketImpl.java:1064)
            at okio.InputStreamSource.read(JvmOkio.kt:93)
            at okio.AsyncTimeout$source$1.read(AsyncTimeout.kt:153)
            at okio.RealBufferedSource.indexOf(RealBufferedSource.kt:434)
            at okio.RealBufferedSource.readUtf8LineStrict(RealBufferedSource.kt:327)
            at okhttp3.internal.http1.HeadersReader.readLine(HeadersReader.kt:29)
            at okhttp3.internal.http1.Http1ExchangeCodec.readResponseHeaders(Http1ExchangeCodec.kt:180)
            at okhttp3.internal.connection.Exchange.readResponseHeaders(Exchange.kt:110)
            at okhttp3.internal.http.CallServerInterceptor.intercept(CallServerInterceptor.kt:93)
            at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.kt:109)
            at okhttp3.internal.connection.ConnectInterceptor.intercept(ConnectInterceptor.kt:34)
            at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.kt:109)
            at okhttp3.internal.cache.CacheInterceptor.intercept(CacheInterceptor.kt:95)
            at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.kt:109)
            at okhttp3.internal.http.BridgeInterceptor.intercept(BridgeInterceptor.kt:83)
            at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.kt:109)
            at okhttp3.internal.http.RetryAndFollowUpInterceptor.intercept(RetryAndFollowUpInterceptor.kt:76)
            at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.kt:109)
            at okhttp3.internal.connection.RealCall.getResponseWithInterceptorChain$okhttp(RealCall.kt:201)
            at okhttp3.internal.connection.RealCall$AsyncCall.run(RealCall.kt:517)
            at java.util.concurrent.ThreadPoolExecutor.runWorker(java.base@18.0.2.1/ThreadPoolExecutor.java:1136)
            at java.util.concurrent.ThreadPoolExecutor$Worker.run(java.base@18.0.2.1/ThreadPoolExecutor.java:635)
            at java.lang.Thread.run(java.base@18.0.2.1/Thread.java:833)
    
       Locked ownable synchronizers:
            - <0x0000000700719bd8> (a java.util.concurrent.ThreadPoolExecutor$Worker)
            - <0x0000000700724d38> (a java.util.concurrent.locks.ReentrantLock$NonfairSync)
            - <0x0000000700a01020> (a java.util.concurrent.locks.ReentrantLock$NonfairSync)
    
    "OkHttp TaskRunner" #21 daemon prio=5 os_prio=31 cpu=0.39ms elapsed=5.70s tid=0x0000000125cc0a00 nid=41475 in Object.wait()  [0x00000001744ee000]
       java.lang.Thread.State: TIMED_WAITING (on object monitor)
            at java.lang.Object.wait(java.base@18.0.2.1/Native Method)
            - waiting on <0x0000000700719df0> (a okhttp3.internal.concurrent.TaskRunner)
            at java.lang.Object.wait(java.base@18.0.2.1/Object.java:472)
            at okhttp3.internal.concurrent.TaskRunner$RealBackend.coordinatorWait(TaskRunner.kt:294)
            at okhttp3.internal.concurrent.TaskRunner.awaitTaskToRun(TaskRunner.kt:218)
            at okhttp3.internal.concurrent.TaskRunner$runnable$1.run(TaskRunner.kt:59)
            - locked <0x0000000700719df0> (a okhttp3.internal.concurrent.TaskRunner)
            at java.util.concurrent.ThreadPoolExecutor.runWorker(java.base@18.0.2.1/ThreadPoolExecutor.java:1136)
            at java.util.concurrent.ThreadPoolExecutor$Worker.run(java.base@18.0.2.1/ThreadPoolExecutor.java:635)
            at java.lang.Thread.run(java.base@18.0.2.1/Thread.java:833)
    
       Locked ownable synchronizers:
            - <0x000000070071a008> (a java.util.concurrent.ThreadPoolExecutor$Worker)
    
    "Okio Watchdog" #22 daemon prio=5 os_prio=31 cpu=0.90ms elapsed=5.70s tid=0x00000001250ec200 nid=40963 waiting on condition  [0x00000001746fa000]
       java.lang.Thread.State: TIMED_WAITING (parking)
            at jdk.internal.misc.Unsafe.park(java.base@18.0.2.1/Native Method)
            - parking to wait for  <0x000000070071a1a8> (a java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject)
            at java.util.concurrent.locks.LockSupport.parkNanos(java.base@18.0.2.1/LockSupport.java:252)
            at java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject.await(java.base@18.0.2.1/AbstractQueuedSynchronizer.java:1757)
            at okio.AsyncTimeout$Companion.awaitTimeout(AsyncTimeout.kt:370)
            at okio.AsyncTimeout$Watchdog.run(AsyncTimeout.kt:211)
    
       Locked ownable synchronizers:
            - None
    
    "DefaultDispatcher-worker-4" #23 daemon prio=5 os_prio=31 cpu=0.41ms elapsed=4.53s tid=0x00000001008eb800 nid=40707 waiting on condition  [0x0000000174906000]
       java.lang.Thread.State: TIMED_WAITING (parking)
            at jdk.internal.misc.Unsafe.park(java.base@18.0.2.1/Native Method)
            at java.util.concurrent.locks.LockSupport.parkNanos(java.base@18.0.2.1/LockSupport.java:376)
            at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.park(CoroutineScheduler.kt:847)
            at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.tryPark(CoroutineScheduler.kt:792)
            at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.runWorker(CoroutineScheduler.kt:740)
            at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.run(CoroutineScheduler.kt:693)
    
       Locked ownable synchronizers:
            - None
    
    "DefaultDispatcher-worker-5" #24 daemon prio=5 os_prio=31 cpu=0.33ms elapsed=4.53s tid=0x00000001008b6e00 nid=40451 waiting on condition  [0x0000000174b12000]
       java.lang.Thread.State: TIMED_WAITING (parking)
            at jdk.internal.misc.Unsafe.park(java.base@18.0.2.1/Native Method)
            at java.util.concurrent.locks.LockSupport.parkNanos(java.base@18.0.2.1/LockSupport.java:376)
            at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.park(CoroutineScheduler.kt:847)
            at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.tryPark(CoroutineScheduler.kt:792)
            at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.runWorker(CoroutineScheduler.kt:740)
            at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.run(CoroutineScheduler.kt:693)
    
       Locked ownable synchronizers:
            - None
    
    "Attach Listener" #25 daemon prio=9 os_prio=31 cpu=158.26ms elapsed=3.14s tid=0x0000000100a8de00 nid=36099 waiting on condition  [0x0000000000000000]
       java.lang.Thread.State: RUNNABLE
    
       Locked ownable synchronizers:
            - None
    
    "JFR Recorder Thread" #26 daemon prio=5 os_prio=31 cpu=0.09ms elapsed=3.01s tid=0x0000000107065800 nid=40195 runnable  [0x0000000000000000]
       java.lang.Thread.State: RUNNABLE
    
       Locked ownable synchronizers:
            - None
    
    "JFR Periodic Tasks" #27 daemon prio=9 os_prio=31 cpu=11.30ms elapsed=2.92s tid=0x0000000123260400 nid=39939 in Object.wait()  [0x0000000175136000]
       java.lang.Thread.State: TIMED_WAITING (on object monitor)
            at java.lang.Object.wait(java.base@18.0.2.1/Native Method)
            - waiting on <no object reference available>
            at jdk.jfr.internal.PlatformRecorder.takeNap(jdk.jfr@18.0.2.1/PlatformRecorder.java:526)
            - locked <0x0000000700e600f8> (a java.lang.Object)
            at jdk.jfr.internal.PlatformRecorder.periodicTask(jdk.jfr@18.0.2.1/PlatformRecorder.java:507)
            at jdk.jfr.internal.PlatformRecorder.lambda$startDiskMonitor$1(jdk.jfr@18.0.2.1/PlatformRecorder.java:447)
            at jdk.jfr.internal.PlatformRecorder$$Lambda$188/0x0000000800ec31c0.run(jdk.jfr@18.0.2.1/Unknown Source)
            at java.lang.Thread.run(java.base@18.0.2.1/Thread.java:833)
    
       Locked ownable synchronizers:
            - None
    
    "DefaultDispatcher-worker-6" #29 daemon prio=5 os_prio=31 cpu=0.38ms elapsed=2.70s tid=0x000000010302ee00 nid=39683 waiting on condition  [0x0000000175342000]
       java.lang.Thread.State: TIMED_WAITING (parking)
            at jdk.internal.misc.Unsafe.park(java.base@18.0.2.1/Native Method)
            at java.util.concurrent.locks.LockSupport.parkNanos(java.base@18.0.2.1/LockSupport.java:376)
            at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.park(CoroutineScheduler.kt:847)
            at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.tryPark(CoroutineScheduler.kt:792)
            at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.runWorker(CoroutineScheduler.kt:740)
            at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.run(CoroutineScheduler.kt:693)
    
       Locked ownable synchronizers:
            - None
    
    "DefaultDispatcher-worker-7" #30 daemon prio=5 os_prio=31 cpu=4.42ms elapsed=2.70s tid=0x0000000103019200 nid=39427 waiting on condition  [0x000000017554e000]
       java.lang.Thread.State: TIMED_WAITING (parking)
            at jdk.internal.misc.Unsafe.park(java.base@18.0.2.1/Native Method)
            at java.util.concurrent.locks.LockSupport.parkNanos(java.base@18.0.2.1/LockSupport.java:376)
            at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.park(CoroutineScheduler.kt:847)
            at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.tryPark(CoroutineScheduler.kt:792)
            at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.runWorker(CoroutineScheduler.kt:740)
            at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.run(CoroutineScheduler.kt:693)
    
       Locked ownable synchronizers:
            - None
    
    "RMI TCP Accept-0" #31 daemon prio=9 os_prio=31 cpu=3.39ms elapsed=2.64s tid=0x00000001250eba00 nid=37635 runnable  [0x000000017575a000]
       java.lang.Thread.State: RUNNABLE
            at sun.nio.ch.Net.accept(java.base@18.0.2.1/Native Method)
            at sun.nio.ch.NioSocketImpl.accept(java.base@18.0.2.1/NioSocketImpl.java:752)
            at java.net.ServerSocket.implAccept(java.base@18.0.2.1/ServerSocket.java:673)
            at java.net.ServerSocket.platformImplAccept(java.base@18.0.2.1/ServerSocket.java:639)
            at java.net.ServerSocket.implAccept(java.base@18.0.2.1/ServerSocket.java:615)
            at java.net.ServerSocket.implAccept(java.base@18.0.2.1/ServerSocket.java:572)
            at java.net.ServerSocket.accept(java.base@18.0.2.1/ServerSocket.java:530)
            at sun.management.jmxremote.LocalRMIServerSocketFactory$1.accept(jdk.management.agent@18.0.2.1/LocalRMIServerSocketFactory.java:52)
            at sun.rmi.transport.tcp.TCPTransport$AcceptLoop.executeAcceptLoop(java.rmi@18.0.2.1/TCPTransport.java:424)
            at sun.rmi.transport.tcp.TCPTransport$AcceptLoop.run(java.rmi@18.0.2.1/TCPTransport.java:388)
            at java.lang.Thread.run(java.base@18.0.2.1/Thread.java:833)
    
       Locked ownable synchronizers:
            - <0x0000000702160f98> (a java.util.concurrent.locks.ReentrantLock$NonfairSync)
    
    "RMI TCP Connection(1)-192.168.0.104" #32 daemon prio=9 os_prio=31 cpu=56.25ms elapsed=2.62s tid=0x0000000123071400 nid=37891 runnable  [0x0000000175965000]
       java.lang.Thread.State: RUNNABLE
            at sun.nio.ch.Net.poll(java.base@18.0.2.1/Native Method)
            at sun.nio.ch.NioSocketImpl.park(java.base@18.0.2.1/NioSocketImpl.java:178)
            at sun.nio.ch.NioSocketImpl.timedRead(java.base@18.0.2.1/NioSocketImpl.java:282)
            at sun.nio.ch.NioSocketImpl.implRead(java.base@18.0.2.1/NioSocketImpl.java:306)
            at sun.nio.ch.NioSocketImpl.read(java.base@18.0.2.1/NioSocketImpl.java:347)
            at sun.nio.ch.NioSocketImpl$1.read(java.base@18.0.2.1/NioSocketImpl.java:800)
            at java.net.Socket$SocketInputStream.read(java.base@18.0.2.1/Socket.java:966)
            at java.io.BufferedInputStream.fill(java.base@18.0.2.1/BufferedInputStream.java:244)
            at java.io.BufferedInputStream.read(java.base@18.0.2.1/BufferedInputStream.java:263)
            - locked <0x0000000702002410> (a java.io.BufferedInputStream)
            at java.io.FilterInputStream.read(java.base@18.0.2.1/FilterInputStream.java:79)
            at sun.rmi.transport.tcp.TCPTransport.handleMessages(java.rmi@18.0.2.1/TCPTransport.java:580)
            at sun.rmi.transport.tcp.TCPTransport$ConnectionHandler.run0(java.rmi@18.0.2.1/TCPTransport.java:844)
            at sun.rmi.transport.tcp.TCPTransport$ConnectionHandler.lambda$run$0(java.rmi@18.0.2.1/TCPTransport.java:721)
            at sun.rmi.transport.tcp.TCPTransport$ConnectionHandler$$Lambda$246/0x0000000801033238.run(java.rmi@18.0.2.1/Unknown Source)
            at java.security.AccessController.executePrivileged(java.base@18.0.2.1/AccessController.java:776)
            at java.security.AccessController.doPrivileged(java.base@18.0.2.1/AccessController.java:399)
            at sun.rmi.transport.tcp.TCPTransport$ConnectionHandler.run(java.rmi@18.0.2.1/TCPTransport.java:720)
            at java.util.concurrent.ThreadPoolExecutor.runWorker(java.base@18.0.2.1/ThreadPoolExecutor.java:1136)
            at java.util.concurrent.ThreadPoolExecutor$Worker.run(java.base@18.0.2.1/ThreadPoolExecutor.java:635)
            at java.lang.Thread.run(java.base@18.0.2.1/Thread.java:833)
    
       Locked ownable synchronizers:
            - <0x0000000702002750> (a java.util.concurrent.ThreadPoolExecutor$Worker)
            - <0x0000000702161f60> (a java.util.concurrent.locks.ReentrantLock$NonfairSync)
    
    "RMI Scheduler(0)" #33 daemon prio=9 os_prio=31 cpu=0.13ms elapsed=2.60s tid=0x0000000100808800 nid=38147 waiting on condition  [0x0000000175b72000]
       java.lang.Thread.State: TIMED_WAITING (parking)
            at jdk.internal.misc.Unsafe.park(java.base@18.0.2.1/Native Method)
            - parking to wait for  <0x000000070203b018> (a java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject)
            at java.util.concurrent.locks.LockSupport.parkNanos(java.base@18.0.2.1/LockSupport.java:252)
            at java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject.awaitNanos(java.base@18.0.2.1/AbstractQueuedSynchronizer.java:1672)
            at java.util.concurrent.ScheduledThreadPoolExecutor$DelayedWorkQueue.take(java.base@18.0.2.1/ScheduledThreadPoolExecutor.java:1182)
            at java.util.concurrent.ScheduledThreadPoolExecutor$DelayedWorkQueue.take(java.base@18.0.2.1/ScheduledThreadPoolExecutor.java:899)
            at java.util.concurrent.ThreadPoolExecutor.getTask(java.base@18.0.2.1/ThreadPoolExecutor.java:1062)
            at java.util.concurrent.ThreadPoolExecutor.runWorker(java.base@18.0.2.1/ThreadPoolExecutor.java:1122)
            at java.util.concurrent.ThreadPoolExecutor$Worker.run(java.base@18.0.2.1/ThreadPoolExecutor.java:635)
            at java.lang.Thread.run(java.base@18.0.2.1/Thread.java:833)
    
       Locked ownable synchronizers:
            - None
    
    "JMX server connection timeout 34" #34 daemon prio=9 os_prio=31 cpu=2.18ms elapsed=2.60s tid=0x0000000123079a00 nid=43523 in Object.wait()  [0x0000000175d7e000]
       java.lang.Thread.State: TIMED_WAITING (on object monitor)
            at java.lang.Object.wait(java.base@18.0.2.1/Native Method)
            - waiting on <no object reference available>
            at com.sun.jmx.remote.internal.ServerCommunicatorAdmin$Timeout.run(java.management@18.0.2.1/ServerCommunicatorAdmin.java:171)
            - locked <0x0000000702058278> (a [I)
            at java.lang.Thread.run(java.base@18.0.2.1/Thread.java:833)
    
       Locked ownable synchronizers:
            - None
    
    "DefaultDispatcher-worker-8" #35 daemon prio=5 os_prio=31 cpu=0.41ms elapsed=1.55s tid=0x0000000107838a00 nid=32007 waiting on condition  [0x0000000175f8a000]
       java.lang.Thread.State: TIMED_WAITING (parking)
            at jdk.internal.misc.Unsafe.park(java.base@18.0.2.1/Native Method)
            at java.util.concurrent.locks.LockSupport.parkNanos(java.base@18.0.2.1/LockSupport.java:376)
            at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.park(CoroutineScheduler.kt:847)
            at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.tryPark(CoroutineScheduler.kt:792)
            at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.runWorker(CoroutineScheduler.kt:740)
            at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.run(CoroutineScheduler.kt:693)
    
       Locked ownable synchronizers:
            - None
    
    "RMI TCP Connection(2)-192.168.0.104" #36 daemon prio=9 os_prio=31 cpu=0.76ms elapsed=1.53s tid=0x0000000100a84000 nid=43779 runnable  [0x0000000176195000]
       java.lang.Thread.State: RUNNABLE
            at sun.nio.ch.Net.poll(java.base@18.0.2.1/Native Method)
            at sun.nio.ch.NioSocketImpl.park(java.base@18.0.2.1/NioSocketImpl.java:178)
            at sun.nio.ch.NioSocketImpl.timedRead(java.base@18.0.2.1/NioSocketImpl.java:282)
            at sun.nio.ch.NioSocketImpl.implRead(java.base@18.0.2.1/NioSocketImpl.java:306)
            at sun.nio.ch.NioSocketImpl.read(java.base@18.0.2.1/NioSocketImpl.java:347)
            at sun.nio.ch.NioSocketImpl$1.read(java.base@18.0.2.1/NioSocketImpl.java:800)
            at java.net.Socket$SocketInputStream.read(java.base@18.0.2.1/Socket.java:966)
            at java.io.BufferedInputStream.fill(java.base@18.0.2.1/BufferedInputStream.java:244)
            at java.io.BufferedInputStream.read(java.base@18.0.2.1/BufferedInputStream.java:263)
            - locked <0x000000070205a528> (a java.io.BufferedInputStream)
            at java.io.FilterInputStream.read(java.base@18.0.2.1/FilterInputStream.java:79)
            at sun.rmi.transport.tcp.TCPTransport.handleMessages(java.rmi@18.0.2.1/TCPTransport.java:580)
            at sun.rmi.transport.tcp.TCPTransport$ConnectionHandler.run0(java.rmi@18.0.2.1/TCPTransport.java:844)
            at sun.rmi.transport.tcp.TCPTransport$ConnectionHandler.lambda$run$0(java.rmi@18.0.2.1/TCPTransport.java:721)
            at sun.rmi.transport.tcp.TCPTransport$ConnectionHandler$$Lambda$246/0x0000000801033238.run(java.rmi@18.0.2.1/Unknown Source)
            at java.security.AccessController.executePrivileged(java.base@18.0.2.1/AccessController.java:776)
            at java.security.AccessController.doPrivileged(java.base@18.0.2.1/AccessController.java:399)
            at sun.rmi.transport.tcp.TCPTransport$ConnectionHandler.run(java.rmi@18.0.2.1/TCPTransport.java:720)
            at java.util.concurrent.ThreadPoolExecutor.runWorker(java.base@18.0.2.1/ThreadPoolExecutor.java:1136)
            at java.util.concurrent.ThreadPoolExecutor$Worker.run(java.base@18.0.2.1/ThreadPoolExecutor.java:635)
            at java.lang.Thread.run(java.base@18.0.2.1/Thread.java:833)
    
       Locked ownable synchronizers:
            - <0x000000070205a7a8> (a java.util.concurrent.ThreadPoolExecutor$Worker)
            - <0x0000000702072a18> (a java.util.concurrent.locks.ReentrantLock$NonfairSync)
    
    "DefaultDispatcher-worker-9" #37 daemon prio=5 os_prio=31 cpu=0.16ms elapsed=0.80s tid=0x0000000107015c00 nid=44291 waiting on condition  [0x00000001763a2000]
       java.lang.Thread.State: TIMED_WAITING (parking)
            at jdk.internal.misc.Unsafe.park(java.base@18.0.2.1/Native Method)
            at java.util.concurrent.locks.LockSupport.parkNanos(java.base@18.0.2.1/LockSupport.java:376)
            at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.park(CoroutineScheduler.kt:847)
            at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.tryPark(CoroutineScheduler.kt:792)
            at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.runWorker(CoroutineScheduler.kt:740)
            at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.run(CoroutineScheduler.kt:693)
    
       Locked ownable synchronizers:
            - None
    
    "DefaultDispatcher-worker-10" #38 daemon prio=5 os_prio=31 cpu=117.05ms elapsed=0.79s tid=0x0000000107837a00 nid=64515 waiting on condition  [0x00000001765ae000]
       java.lang.Thread.State: TIMED_WAITING (parking)
            at jdk.internal.misc.Unsafe.park(java.base@18.0.2.1/Native Method)
            at java.util.concurrent.locks.LockSupport.parkNanos(java.base@18.0.2.1/LockSupport.java:376)
            at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.park(CoroutineScheduler.kt:847)
            at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.tryPark(CoroutineScheduler.kt:792)
            at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.runWorker(CoroutineScheduler.kt:740)
            at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.run(CoroutineScheduler.kt:693)
    
       Locked ownable synchronizers:
            - None
    
    "DefaultDispatcher-worker-11" #39 daemon prio=5 os_prio=31 cpu=0.35ms elapsed=0.79s tid=0x0000000107838000 nid=64003 waiting on condition  [0x00000001767ba000]
       java.lang.Thread.State: TIMED_WAITING (parking)
            at jdk.internal.misc.Unsafe.park(java.base@18.0.2.1/Native Method)
            at java.util.concurrent.locks.LockSupport.parkNanos(java.base@18.0.2.1/LockSupport.java:376)
            at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.park(CoroutineScheduler.kt:847)
            at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.tryPark(CoroutineScheduler.kt:792)
            at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.runWorker(CoroutineScheduler.kt:740)
            at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.run(CoroutineScheduler.kt:693)
    
       Locked ownable synchronizers:
            - None
    
    "DefaultDispatcher-worker-12" #40 daemon prio=5 os_prio=31 cpu=0.22ms elapsed=0.79s tid=0x0000000107839000 nid=44547 waiting on condition  [0x00000001769c6000]
       java.lang.Thread.State: TIMED_WAITING (parking)
            at jdk.internal.misc.Unsafe.park(java.base@18.0.2.1/Native Method)
            at java.util.concurrent.locks.LockSupport.parkNanos(java.base@18.0.2.1/LockSupport.java:376)
            at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.park(CoroutineScheduler.kt:847)
            at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.tryPark(CoroutineScheduler.kt:792)
            at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.runWorker(CoroutineScheduler.kt:740)
            at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.run(CoroutineScheduler.kt:693)
    
       Locked ownable synchronizers:
            - None
    
    "VM Thread" os_prio=31 cpu=26.75ms elapsed=7.48s tid=0x0000000122e069b0 nid=19971 runnable
    
    "GC Thread#0" os_prio=31 cpu=12.28ms elapsed=7.50s tid=0x0000000123906780 nid=13059 runnable
    
    "GC Thread#1" os_prio=31 cpu=10.73ms elapsed=7.18s tid=0x0000000102e077c0 nid=28163 runnable
    
    "GC Thread#2" os_prio=31 cpu=7.12ms elapsed=7.18s tid=0x0000000101011030 nid=25603 runnable
    
    "GC Thread#3" os_prio=31 cpu=11.76ms elapsed=7.18s tid=0x0000000100708d30 nid=25859 runnable
    
    "GC Thread#4" os_prio=31 cpu=8.39ms elapsed=7.18s tid=0x00000001007091a0 nid=27395 runnable
    
    "GC Thread#5" os_prio=31 cpu=12.78ms elapsed=7.18s tid=0x0000000102e07c30 nid=27139 runnable
    
    "GC Thread#6" os_prio=31 cpu=12.82ms elapsed=6.78s tid=0x0000000100711cb0 nid=33539 runnable
    
    "GC Thread#7" os_prio=31 cpu=6.94ms elapsed=6.53s tid=0x0000000122f32c00 nid=42755 runnable
    
    "GC Thread#8" os_prio=31 cpu=4.12ms elapsed=6.53s tid=0x0000000123832730 nid=42243 runnable
    
    "G1 Main Marker" os_prio=31 cpu=0.26ms elapsed=7.50s tid=0x0000000123906e20 nid=13315 runnable
    
    "G1 Conc#0" os_prio=31 cpu=13.34ms elapsed=7.50s tid=0x0000000123907690 nid=13827 runnable
    
    "G1 Conc#1" os_prio=31 cpu=13.20ms elapsed=6.53s tid=0x0000000122e31ce0 nid=34563 runnable
    
    "G1 Refine#0" os_prio=31 cpu=0.04ms elapsed=7.50s tid=0x00000001239147b0 nid=16899 runnable
    
    "G1 Service" os_prio=31 cpu=0.91ms elapsed=7.50s tid=0x0000000123915030 nid=21507 runnable
    
    "VM Periodic Task Thread" os_prio=31 cpu=2.77ms elapsed=7.36s tid=0x000000012380b9d0 nid=25091 waiting on condition
    
</details>

## Notes
I noticed through my investigations that we are depending heavily on [`io.ktor.utils.io`](https://api.ktor.io/ktor-io/io.ktor.utils.io/index.html). The issue is that a lot of the internals of the mentioned package are getting or already have been deprecated. 

We should make sure that our codebase does not unnecessarily depend on deprecated, unmaintained components. Based on [`KTOR-3060`](https://youtrack.jetbrains.com/issue/KTOR-6030/Migrate-to-new-kotlinx.io-library), we should migrate to the new kotlinx.io library.