### PR TITLE
fix: remove all leading slashes from a URL path segment

### DIFF
--- a/generator/openapi/src/main/kotlin/com/expediagroup/sdk/generators/openapi/MustacheHelpers.kt
+++ b/generator/openapi/src/main/kotlin/com/expediagroup/sdk/generators/openapi/MustacheHelpers.kt
@@ -22,7 +22,7 @@ import org.openapitools.codegen.model.OperationsMap
 
 val mustacheHelpers = mapOf(
     "removeLeadingSlash" to {
-        Mustache.Lambda { fragment, writer -> writer.write(fragment.execute().removePrefix("/")) }
+        Mustache.Lambda { fragment, writer -> writer.write(fragment.execute().replace("^/+".toRegex(), "")) }
     },
     "assignDiscriminators" to {
         Mustache.Lambda { fragment, writer ->


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [x] Code is up-to-date with the `main` branch.
* [ ] You've successfully built and run the tests locally.
* [ ] There are new or updated unit tests validating the change.

Refer to CONTRIBUTING.md for more details.
-->

### :pencil: Description
Ktor's [DefaultRequest](https://api.ktor.io/ktor-client/ktor-client-core/io.ktor.client.plugins/-default-request/index.html) plugin uses the request path as is if it starts with a slash. This PR removes leading slashes from request paths to avoid this behavior


### :link: Related Issues
- 
