### PR TITLE
fix: add a deprecated getBody to Responses, and fix operation execution with empty responses

### DIFF
--- a/core/src/main/kotlin/com/expediagroup/sdk/core/model/Response.kt
+++ b/core/src/main/kotlin/com/expediagroup/sdk/core/model/Response.kt
@@ -46,7 +46,10 @@ open class Response<T>(
             )
     }
 
-    override fun toString(): String = "Response(statusCode=$statusCode, data=$data, headers=$headers)"
+    override fun toString() = "Response(statusCode=$statusCode, data=$data, headers=$headers)"
+
+    @Deprecated("Use getData() instead", replaceWith = ReplaceWith("getData()"))
+    fun getBody() = data
 }
 
 class EmptyResponse(

--- a/core/src/test/kotlin/com/expediagroup/sdk/core/model/TransactionIdTest.kt
+++ b/core/src/test/kotlin/com/expediagroup/sdk/core/model/TransactionIdTest.kt
@@ -1,0 +1,30 @@
+package com.expediagroup.sdk.core.model
+
+import io.mockk.every
+import io.mockk.mockkStatic
+import org.junit.jupiter.api.Test
+import java.util.UUID
+
+class TransactionIdTest {
+    private val uuids = listOf(UUID.randomUUID(), UUID.randomUUID())
+
+    @Test
+    fun `peek should return a UUID`() {
+        mockkStatic(UUID::class) {
+            every { UUID.randomUUID() } returnsMany uuids
+            val transactionId = TransactionId()
+            assert(transactionId.peek() == uuids[0])
+            assert(transactionId.peek() == uuids[0])
+        }
+    }
+
+    @Test
+    fun `dequeue should return a UUID and change it`() {
+        mockkStatic(UUID::class) {
+            every { UUID.randomUUID() } returnsMany uuids
+            val transactionId = TransactionId()
+            assert(transactionId.dequeue() == uuids[0])
+            assert(transactionId.peek() == uuids[1])
+        }
+    }
+}

--- a/generator/openapi/src/main/kotlin/com/expediagroup/sdk/generators/openapi/MustacheHelpers.kt
+++ b/generator/openapi/src/main/kotlin/com/expediagroup/sdk/generators/openapi/MustacheHelpers.kt
@@ -80,10 +80,8 @@ val mustacheHelpers = mapOf(
             }
 
             dataTypes.forEach { dataType ->
-                writer.write(
-                    "class ExpediaGroupApi${dataType}Exception(code: Int, override val errorObject: $dataType, transactionId: String?) : " +
-                        "ExpediaGroupApiException(code, errorObject, transactionId)\n"
-                )
+                val context = mapOf("dataType" to dataType)
+                fragment.execute(context, writer)
             }
         }
     },

--- a/generator/openapi/src/main/resources/templates/expediagroup-sdk/client.mustache
+++ b/generator/openapi/src/main/resources/templates/expediagroup-sdk/client.mustache
@@ -38,27 +38,42 @@ class {{#lambda.titlecase}}{{namespace}}{{/lambda.titlecase}}Client private cons
         throw ErrorObjectMapper.process(response, operationId)
     }
 
+    private suspend inline fun <reified RequestType> executeHttpRequest(operation: Operation<RequestType>): HttpResponse {
+        return httpClient.request {
+            method = HttpMethod.parse(operation.method)
+            url(operation.url)
+
+            operation.params.getHeaders()?.forEach { (key, value) ->
+                headers.append(key, value)
+            }
+
+            operation.params.getQueryParams()?.forEach { (key, value) ->
+                url.parameters.appendAll(key, value)
+            }
+
+            appendHeaders(operation.transactionId)
+            validateConstraints(operation.requestBody)
+            contentType(ContentType.Application.Json)
+            setBody(operation.requestBody)
+        }
+    }
+
+    private inline fun <reified RequestType> executeWithEmptyResponse(operation: Operation<RequestType>) : EmptyResponse {
+        try {
+            return GlobalScope.future(Dispatchers.IO) {
+                val response = executeHttpRequest(operation)
+                throwIfError(response, operation.operationId)
+                EmptyResponse(response.status.value, response.headers.entries())
+            }.get()
+        } catch (exception: Exception) {
+            exception.handle()
+        }
+    }
+
     private inline fun <reified RequestType, reified ResponseType> execute(operation: Operation<RequestType>) : Response<ResponseType> {
         try {
             return GlobalScope.future(Dispatchers.IO) {
-                val response = httpClient.request {
-                    method = HttpMethod.parse(operation.method)
-                    url(operation.url)
-
-                    operation.params.getHeaders()?.forEach { (key, value) ->
-                        headers.append(key, value)
-                    }
-
-                    operation.params.getQueryParams()?.forEach { (key, value) ->
-                        url.parameters.appendAll(key, value)
-                    }
-
-                    appendHeaders(operation.transactionId)
-                    validateConstraints(operation.requestBody)
-                    contentType(ContentType.Application.Json)
-                    setBody(operation.requestBody)
-                }
-
+                val response = executeHttpRequest(operation)
                 throwIfError(response, operation.operationId)
                 Response(response.status.value, response.body<ResponseType>(), response.headers.entries())
             }.get()
@@ -75,11 +90,13 @@ class {{#lambda.titlecase}}{{namespace}}{{/lambda.titlecase}}Client private cons
         {{#throwsExceptions}}{{/throwsExceptions}}
         * @return a [Response] object with a body of type {{{returnType}}}{{^returnType}}Nothing{{/returnType}}
         */
-        fun execute(operation: {{operationIdCamelCase}}Operation) : {{#returnType}}Response<{{{returnType}}}>{{/returnType}}{{^returnType}}Response<Nothing>{{/returnType}} {
-            return execute<
-                {{#bodyParam}}{{dataType}}{{/bodyParam}}{{^hasBodyParam}}Nothing{{/hasBodyParam}},
-                {{{returnType}}}{{^returnType}}Nothing{{/returnType}}
-            >(operation)
+        fun execute(operation: {{operationIdCamelCase}}Operation) : {{#returnType}}Response<{{{returnType}}}>{{/returnType}}{{^returnType}}EmptyResponse{{/returnType}} {
+            {{#returnType}}
+                return execute<{{#bodyParam}}{{dataType}}{{/bodyParam}}{{^hasBodyParam}}Nothing{{/hasBodyParam}}, {{{returnType}}}>(operation)
+            {{/returnType}}
+            {{^returnType}}
+                return executeWithEmptyResponse<{{#bodyParam}}{{dataType}}{{/bodyParam}}{{^hasBodyParam}}Nothing{{/hasBodyParam}}>(operation)
+            {{/returnType}}
         }
 
         private suspend {{^isKotlin}}inline {{/isKotlin}}fun {{^isKotlin}}k{{/isKotlin}}{{operationId}}WithResponse({{>client/apiParamsDecleration}}): {{#returnType}}Response<{{{returnType}}}>{{/returnType}}{{^returnType}}Response<Nothing>{{/returnType}} {

--- a/generator/openapi/src/main/resources/templates/expediagroup-sdk/models/apiException.mustache
+++ b/generator/openapi/src/main/resources/templates/expediagroup-sdk/models/apiException.mustache
@@ -60,5 +60,7 @@ internal object ErrorObjectMapper {
 }
 
 {{#apiInfo}}
-    {{#defineApiExceptions}}{{/defineApiExceptions}}
+    {{#defineApiExceptions}}
+        class ExpediaGroupApi{{dataType}}Exception(code: Int, override val errorObject: {{dataType}}, transactionId: String?) : ExpediaGroupApiException(code, errorObject, transactionId)
+    {{/defineApiExceptions}}
 {{/apiInfo}}


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [x] Code is up-to-date with the `main` branch.
* [x] You've successfully built and run the tests locally.
* [ ] There are new or updated unit tests validating the change.

Refer to CONTRIBUTING.md for more details.
-->

### :pencil: Description

- fix: add a deprecated getBody to `Response`
- fix: execution of operations with empty responses
- chore: add tests for `TransactionId`
- chore: clean up apiExceptions mustache helper
- chore: clean up mustache helpers
