### PR TITLE
fix: use logging guards

### DIFF
--- a/core/src/main/kotlin/com/expediagroup/sdk/core/plugin/logging/ExpediaGroupLogger.kt
+++ b/core/src/main/kotlin/com/expediagroup/sdk/core/plugin/logging/ExpediaGroupLogger.kt
@@ -21,11 +21,24 @@ import com.expediagroup.sdk.core.constant.LoggingMessage.LOGGING_PREFIX
 import org.slf4j.Logger
 
 internal class ExpediaGroupLogger(private val logger: Logger, private val client: Client? = null) : Logger by logger {
-    override fun info(msg: String) = logger.info(decorate(msg))
+    override fun info(msg: String) {
+        if (logger.isInfoEnabled) {
+            logger.info(decorate(msg))
+        }
+    }
 
-    override fun warn(msg: String) = logger.warn(decorate(msg))
+    override fun warn(msg: String) {
+        if (logger.isWarnEnabled) {
+            logger.warn(decorate(msg))
+        }
 
-    override fun debug(msg: String) = logger.debug(decorate(msg))
+    }
+
+    override fun debug(msg: String) {
+        if (logger.isDebugEnabled) {
+            logger.debug(decorate(msg))
+        }
+    }
 
     private fun decorate(msg: String): String = "$LOGGING_PREFIX ${mask(msg, getMaskedBodyFields())}"
 

--- a/core/src/main/kotlin/com/expediagroup/sdk/core/plugin/logging/LoggingConfiguration.kt
+++ b/core/src/main/kotlin/com/expediagroup/sdk/core/plugin/logging/LoggingConfiguration.kt
@@ -26,7 +26,7 @@ internal data class LoggingConfiguration(
     override val httpClientConfiguration: HttpClientConfig<out HttpClientEngineConfig>,
     val maskedLoggingHeaders: Set<String>,
     val maskedLoggingBodyFields: Set<String>,
-    val level: LogLevel = LogLevel.ALL,
+    val level: LogLevel = LogLevel.HEADERS,
     val getLogger: (client: Client) -> Logger = createCustomLogger
 ) : KtorPluginConfiguration(httpClientConfiguration) {
     companion object {

--- a/core/src/test/kotlin/com/expediagroup/sdk/core/plugin/logging/ExpediaGroupLoggerTest.kt
+++ b/core/src/test/kotlin/com/expediagroup/sdk/core/plugin/logging/ExpediaGroupLoggerTest.kt
@@ -117,6 +117,8 @@ class ExpediaGroupLoggerTest {
         val mockedLogger: Logger = mockkClass(Logger::class)
         every { mockedLogger.info(any()) }.answers { }
         every { mockedLogger.warn(any()) }.answers { }
+        every { mockedLogger.isInfoEnabled }.answers { true }
+        every { mockedLogger.isWarnEnabled }.answers { true }
         return mockedLogger
     }
 }


### PR DESCRIPTION
Please verify that:
* [x] Code is up-to-date with the `main` branch.
* [x] You've successfully built and run the tests locally.
* [x] There are new or updated unit tests validating the change.

Refer to CONTRIBUTING.md for more details.

### :pencil: Description
Logger uses an expensive regex to mask sensitive fields. Use logging guards to avoid the cost of masking when a message is not going to be logged based on its log level