### PR TITLE
chore: add string to pascal case extension

### DIFF
--- a/generator/openapi/src/main/kotlin/com/expediagroup/sdk/generators/openapi/Extensions.kt
+++ b/generator/openapi/src/main/kotlin/com/expediagroup/sdk/generators/openapi/Extensions.kt
@@ -3,17 +3,12 @@ package com.expediagroup.sdk.generators.openapi
 fun String.toPascalCase(): String {
     var capitalizeNext = true
     val builder = StringBuilder()
-
-    forEach {
+    forEach { char ->
         when {
-            it.isDigit() || it == ' ' || it == '-' || it == '_' -> capitalizeNext = true
-            capitalizeNext -> {
-                builder.append(it.uppercaseChar())
-                capitalizeNext = false
-            }
-            else -> builder.append(it)
+            char.isLetterOrDigit().and(capitalizeNext) -> builder.append(char.uppercaseChar())
+            char.isLetterOrDigit() -> builder.append(char)
         }
+        capitalizeNext = char.isLetter().not().or(builder.isEmpty())
     }
-
     return builder.toString()
 }

--- a/generator/openapi/src/main/kotlin/com/expediagroup/sdk/generators/openapi/Extensions.kt
+++ b/generator/openapi/src/main/kotlin/com/expediagroup/sdk/generators/openapi/Extensions.kt
@@ -1,5 +1,13 @@
 package com.expediagroup.sdk.generators.openapi
 
+/**
+ * This extension function converts a string to PascalCase.
+ * PascalCase is a type of identifier that consists of compound words or phrases such that each word or abbreviation begins with a capital letter.
+ * Non-alphabetic characters are ignored, and the next alphabetic character after them is capitalized.
+ *
+ * @receiver String The string to be converted to PascalCase.
+ * @return String The string converted to PascalCase.
+ */
 fun String.pascalCase(): String {
     var capitalizeNext = true
     val builder = StringBuilder()

--- a/generator/openapi/src/main/kotlin/com/expediagroup/sdk/generators/openapi/Extensions.kt
+++ b/generator/openapi/src/main/kotlin/com/expediagroup/sdk/generators/openapi/Extensions.kt
@@ -1,6 +1,6 @@
 package com.expediagroup.sdk.generators.openapi
 
-fun String.toPascalCase(): String {
+fun String.pascalCase(): String {
     var capitalizeNext = true
     val builder = StringBuilder()
     forEach { char ->

--- a/generator/openapi/src/main/kotlin/com/expediagroup/sdk/generators/openapi/Extensions.kt
+++ b/generator/openapi/src/main/kotlin/com/expediagroup/sdk/generators/openapi/Extensions.kt
@@ -1,0 +1,19 @@
+package com.expediagroup.sdk.generators.openapi
+
+fun String.toPascalCase(): String {
+    var capitalizeNext = true
+    val builder = StringBuilder()
+
+    forEach {
+        when {
+            it.isDigit() || it == ' ' || it == '-' || it == '_' -> capitalizeNext = true
+            capitalizeNext -> {
+                builder.append(it.uppercaseChar())
+                capitalizeNext = false
+            }
+            else -> builder.append(it)
+        }
+    }
+
+    return builder.toString()
+}

--- a/generator/openapi/src/main/kotlin/com/expediagroup/sdk/generators/openapi/OpenApiSdkGenerator.kt
+++ b/generator/openapi/src/main/kotlin/com/expediagroup/sdk/generators/openapi/OpenApiSdkGenerator.kt
@@ -107,7 +107,7 @@ class OpenApiSdkGenerator {
                     // Template specific properties
                     addAdditionalProperty("shadePrefix", product.shadePrefix)
                     addAdditionalProperty("namespace", product.namespace)
-                    addAdditionalProperty("clientClassname", namespace.toPascalCase())
+                    addAdditionalProperty("clientClassname", namespace.pascalCase())
                     addAdditionalProperty("language", product.programmingLanguage.id)
                     addAdditionalProperty("isKotlin", ProgrammingLanguage.isKotlin(product.programmingLanguage))
                     addAdditionalProperty("isRapid", ProductFamily.isRapid(product.namespace))

--- a/generator/openapi/src/main/kotlin/com/expediagroup/sdk/generators/openapi/OpenApiSdkGenerator.kt
+++ b/generator/openapi/src/main/kotlin/com/expediagroup/sdk/generators/openapi/OpenApiSdkGenerator.kt
@@ -107,7 +107,7 @@ class OpenApiSdkGenerator {
                     // Template specific properties
                     addAdditionalProperty("shadePrefix", product.shadePrefix)
                     addAdditionalProperty("namespace", product.namespace)
-                    addAdditionalProperty("clientClassname", namespace.replaceFirstChar { it.uppercaseChar() })
+                    addAdditionalProperty("clientClassname", namespace.toPascalCase())
                     addAdditionalProperty("language", product.programmingLanguage.id)
                     addAdditionalProperty("isKotlin", ProgrammingLanguage.isKotlin(product.programmingLanguage))
                     addAdditionalProperty("isRapid", ProductFamily.isRapid(product.namespace))


### PR DESCRIPTION
## What does this PR do?
* Adds a String extension method `pascalCase()` that transforms any `String` instance into [`Pascal Case`](https://en.wikipedia.org/wiki/Camel_case). 
* Uses the newly proposed method as a client class-name factory with product namespace as input.

## How it works?
* Ignores special characters or whitespaces.
* Capitalizes any character after finding a non-alphabetical character.
* Utilizes a `StringBuilder` to build the new string value.
* Not an in-place method.