### PR TITLE
chore: add separate pr tests check workflow

### DIFF
--- a/.github/workflows/core-upgrade.yaml
+++ b/.github/workflows/core-upgrade.yaml
@@ -93,6 +93,7 @@ jobs:
         with:
           name: branch-name
           path: branch_name.txt
+          overwrite: true
 
       - name: Publish Updated Version PR
         uses: peter-evans/create-pull-request@v6

--- a/.github/workflows/generator-download-specs.yaml
+++ b/.github/workflows/generator-download-specs.yaml
@@ -18,3 +18,4 @@ jobs:
         with:
           name: raw-specs
           path: raw-specs.yaml
+          overwrite: true

--- a/.github/workflows/generator-generate.yaml
+++ b/.github/workflows/generator-generate.yaml
@@ -41,13 +41,16 @@ jobs:
           path: |
             generator/openapi/target/sdk
             !generator/openapi/target/sdk/target
+          overwrite: true
       - uses: actions/upload-artifact@v4
         with:
           name: jar
           path: |
             generator/openapi/target/sdk/target/*.jar
             generator/openapi/target/sdk/target/maven-archiver/pom.properties
+          overwrite: true
       - uses: actions/upload-artifact@v4
         with:
           name: docs
           path: generator/openapi/target/sdk/target/dokka
+          overwrite: true

--- a/.github/workflows/generator-test-sdk.yaml
+++ b/.github/workflows/generator-test-sdk.yaml
@@ -14,7 +14,7 @@ on:
         description: 'Endpoint to prepend specs paths with'
         required: true
         type: string
-    specs_url:
+      specs_url:
         description: 'Run tests based on specs'
         required: true
         type: string

--- a/.github/workflows/generator-test-sdk.yaml
+++ b/.github/workflows/generator-test-sdk.yaml
@@ -14,6 +14,10 @@ on:
         description: 'Endpoint to prepend specs paths with'
         required: true
         type: string
+    specs_url:
+        description: 'Run tests based on specs'
+        required: true
+        type: string
     outputs:
       artifactId:
         value: ${{ jobs.sdk-metadata.outputs.artifactId }}

--- a/.github/workflows/generator-transform-specs.yaml
+++ b/.github/workflows/generator-transform-specs.yaml
@@ -20,3 +20,4 @@ jobs:
         with:
           name: specs
           path: specs.yaml
+          overwrite: true

--- a/.github/workflows/generator-verify.yaml
+++ b/.github/workflows/generator-verify.yaml
@@ -27,6 +27,7 @@ jobs:
         with:
           name: sdk
           path: generator/openapi/target/sdk
+          overwrite: true
   verify-generated-sdk:
     runs-on: ubuntu-latest
     needs: generate-sdk

--- a/.github/workflows/pr-check-tests.yaml
+++ b/.github/workflows/pr-check-tests.yaml
@@ -1,15 +1,19 @@
 name: Run Tests
 on: push
 
-jobs: 
-  run-rapid-tests-21:
+jobs:
+  run-rapid-tests:
+    strategy:
+      matrix:
+        jdk: [8, 11, 17, 21]
+      fail-fast: true
+      max-parallel: 1
     uses: ./.github/workflows/run-tests.yaml
     with:
       source: 'specs'
       specs_url: 'https://ewe-assets.s3.amazonaws.com/developer-tools/api/rapid/v3/specs.yaml'
       sdk_version: 1.0.${{ github.run_id }}
       sdk_namespace: 'rapid'
-      jdk: 21
+      jdk: ${{ matrix.jdk }}
       endpoint_prefix: '/v3'
     secrets: inherit
-    

--- a/.github/workflows/pr-check-tests.yaml
+++ b/.github/workflows/pr-check-tests.yaml
@@ -2,15 +2,38 @@ name: Run Tests
 on: push
 
 jobs: 
-  run-rapid-tests:
-    strategy:
-      matrix:
-        jdk: [21, 17, 11, 8]
+  run-rapid-tests-21:
+    uses: ./.github/workflows/run-tests.yaml
+    with:
+      source: 'specs'
+      specs_url: 'https://ewe-assets.s3.amazonaws.com/developer-tools/api/rapid/v3/specs.yaml'
+      sdk_version: 1.0.${{ github.run_id }}
+      sdk_namespace: 'rapid'
+      jdk: 21
+      endpoint_prefix: '/v3'
+  run-rapid-tests-17:
+    uses: ./.github/workflows/run-tests.yaml
+    with:
+      source: 'specs'
+      specs_url: 'https://ewe-assets.s3.amazonaws.com/developer-tools/api/rapid/v3/specs.yaml'
+      sdk_version: 1.0.${{ github.run_id }}
+      sdk_namespace: 'rapid'
+      jdk: '17'
+      endpoint_prefix: '/v3'
+  run-rapid-tests-11:
     uses: ./.github/workflows/run-tests.yaml
     with: 
       source: 'specs'
       specs_url: 'https://ewe-assets.s3.amazonaws.com/developer-tools/api/rapid/v3/specs.yaml'
       sdk_version: 1.0.${{ github.run_id }}
       sdk_namespace: 'rapid'
-      jdk: ${{ matrix.jdk }}
+      jdk: '11'
       endpoint_prefix: '/v3'
+  run-rapid-tests-8:
+    uses: ./.github/workflows/run-tests.yaml
+    with:
+      source: 'specs'
+      specs_url: 'https://ewe-assets.s3.amazonaws.com/developer-tools/api/rapid/v3/specs.yaml'
+      sdk_version: 1.0.${{ github.run_id }}
+      sdk_namespace: 'rapid'
+      jdk: '8'

--- a/.github/workflows/pr-check-tests.yaml
+++ b/.github/workflows/pr-check-tests.yaml
@@ -3,39 +3,15 @@ on:
   push:
 
 jobs: 
-  run-rapid-tests-21:
+  run-rapid-tests:
+    strategy:
+      matrix:
+        jdk: [21, 17, 11, 8]
     uses: ./.github/workflows/run-tests.yaml
     with: 
       source: 'specs'
       specs_url: 'https://ewe-assets.s3.amazonaws.com/developer-tools/api/rapid/v3/specs.yaml'
       sdk_version: 1.0.${{ github.run_id }}
       sdk_namespace: 'rapid'
-      jdk: 21
-      endpoint_prefix: '/v3'
-  run-rapid-tests-17:
-    uses: ./.github/workflows/run-tests.yaml
-    with: 
-      source: 'specs'
-      specs_url: 'https://ewe-assets.s3.amazonaws.com/developer-tools/api/rapid/v3/specs.yaml'
-      sdk_version: 1.0.${{ github.run_id }}
-      sdk_namespace: 'rapid'
-      jdk: '17'
-      endpoint_prefix: '/v3'
-  run-rapid-tests-11:
-    uses: ./.github/workflows/run-tests.yaml
-    with: 
-      source: 'specs'
-      specs_url: 'https://ewe-assets.s3.amazonaws.com/developer-tools/api/rapid/v3/specs.yaml'
-      sdk_version: 1.0.${{ github.run_id }}
-      sdk_namespace: 'rapid'
-      jdk: '11'
-      endpoint_prefix: '/v3'
-  run-rapid-tests-8:
-    uses: ./.github/workflows/run-tests.yaml
-    with: 
-      source: 'specs'
-      specs_url: 'https://ewe-assets.s3.amazonaws.com/developer-tools/api/rapid/v3/specs.yaml'
-      sdk_version: 1.0.${{ github.run_id }}
-      sdk_namespace: 'rapid'
-      jdk: '8'
+      jdk: ${{ matrix.jdk }}
       endpoint_prefix: '/v3'

--- a/.github/workflows/pr-check-tests.yaml
+++ b/.github/workflows/pr-check-tests.yaml
@@ -1,4 +1,4 @@
-name: Run Tests
+name: PR Check Tests Run
 on: push
 
 jobs:

--- a/.github/workflows/pr-check-tests.yaml
+++ b/.github/workflows/pr-check-tests.yaml
@@ -1,7 +1,8 @@
 name: Run Tests
 on:
-  push:
-    branches: [*]
+  pull_request:
+    branches:
+      - *
 
 jobs: 
   run-rapid-tests:

--- a/.github/workflows/pr-check-tests.yaml
+++ b/.github/workflows/pr-check-tests.yaml
@@ -11,3 +11,5 @@ jobs:
       sdk_namespace: 'rapid'
       jdk: 21
       endpoint_prefix: '/v3'
+    secrets: inherit
+    

--- a/.github/workflows/pr-check-tests.yaml
+++ b/.github/workflows/pr-check-tests.yaml
@@ -1,6 +1,7 @@
 name: Run Tests
 on:
   push:
+    branches: [*]
 
 jobs: 
   run-rapid-tests:

--- a/.github/workflows/pr-check-tests.yaml
+++ b/.github/workflows/pr-check-tests.yaml
@@ -11,29 +11,3 @@ jobs:
       sdk_namespace: 'rapid'
       jdk: 21
       endpoint_prefix: '/v3'
-  run-rapid-tests-17:
-    uses: ./.github/workflows/run-tests.yaml
-    with:
-      source: 'specs'
-      specs_url: 'https://ewe-assets.s3.amazonaws.com/developer-tools/api/rapid/v3/specs.yaml'
-      sdk_version: 1.0.${{ github.run_id }}
-      sdk_namespace: 'rapid'
-      jdk: '17'
-      endpoint_prefix: '/v3'
-  run-rapid-tests-11:
-    uses: ./.github/workflows/run-tests.yaml
-    with: 
-      source: 'specs'
-      specs_url: 'https://ewe-assets.s3.amazonaws.com/developer-tools/api/rapid/v3/specs.yaml'
-      sdk_version: 1.0.${{ github.run_id }}
-      sdk_namespace: 'rapid'
-      jdk: '11'
-      endpoint_prefix: '/v3'
-  run-rapid-tests-8:
-    uses: ./.github/workflows/run-tests.yaml
-    with:
-      source: 'specs'
-      specs_url: 'https://ewe-assets.s3.amazonaws.com/developer-tools/api/rapid/v3/specs.yaml'
-      sdk_version: 1.0.${{ github.run_id }}
-      sdk_namespace: 'rapid'
-      jdk: '8'

--- a/.github/workflows/pr-check-tests.yaml
+++ b/.github/workflows/pr-check-tests.yaml
@@ -1,8 +1,5 @@
 name: Run Tests
-on:
-  pull_request:
-    branches:
-      - *
+on: push
 
 jobs: 
   run-rapid-tests:

--- a/.github/workflows/pr-check-tests.yaml
+++ b/.github/workflows/pr-check-tests.yaml
@@ -1,0 +1,41 @@
+name: Run Tests
+on:
+  push:
+
+jobs: 
+  run-rapid-tests-21:
+    uses: ./.github/workflows/run-tests.yaml
+    with: 
+      source: 'specs'
+      specs_url: 'https://ewe-assets.s3.amazonaws.com/developer-tools/api/rapid/v3/specs.yaml'
+      sdk_version: 1.0.${{ github.run_id }}
+      sdk_namespace: 'rapid'
+      jdk: 21
+      endpoint_prefix: '/v3'
+  run-rapid-tests-17:
+    uses: ./.github/workflows/run-tests.yaml
+    with: 
+      source: 'specs'
+      specs_url: 'https://ewe-assets.s3.amazonaws.com/developer-tools/api/rapid/v3/specs.yaml'
+      sdk_version: 1.0.${{ github.run_id }}
+      sdk_namespace: 'rapid'
+      jdk: '17'
+      endpoint_prefix: '/v3'
+  run-rapid-tests-11:
+    uses: ./.github/workflows/run-tests.yaml
+    with: 
+      source: 'specs'
+      specs_url: 'https://ewe-assets.s3.amazonaws.com/developer-tools/api/rapid/v3/specs.yaml'
+      sdk_version: 1.0.${{ github.run_id }}
+      sdk_namespace: 'rapid'
+      jdk: '11'
+      endpoint_prefix: '/v3'
+  run-rapid-tests-8:
+    uses: ./.github/workflows/run-tests.yaml
+    with: 
+      source: 'specs'
+      specs_url: 'https://ewe-assets.s3.amazonaws.com/developer-tools/api/rapid/v3/specs.yaml'
+      sdk_version: 1.0.${{ github.run_id }}
+      sdk_namespace: 'rapid'
+      jdk: '8'
+      endpoint_prefix: '/v3'

--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -92,7 +92,7 @@ jobs:
       version: ${{ inputs.sdk_version }}
       namespace: ${{ inputs.sdk_namespace }}
       endpoint_prefix: ${{ inputs.endpoint_prefix }}
-
+      specs_url: ${{ inputs.specs_url }}
     secrets: inherit
   run-rapid-examples:
     if: always() && !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled')
@@ -102,7 +102,6 @@ jobs:
       sdk_version: ${{ needs.generate-test-sdk.outputs.version }}
       jdk: ${{ inputs.jdk }}
       sdk_generation_workflow_run_id: ${{ github.run_id }}
-      specs_url: ${{ inputs.specs_url }}
     secrets:
       KEY: ${{ secrets.RAPID_KEY }}
       SECRET: ${{ secrets.RAPID_SECRET }}

--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -85,7 +85,7 @@ jobs:
             print('::error::Invalid SDK version: ${{ inputs.sdk_version }}')
             exit(1)
   generate-test-sdk:
-    if: ${{ inputs.source == 'specs' }}
+    if: inputs.source == 'specs'
     needs: [ inputs-validation ]
     uses: ./.github/workflows/generator-test-sdk.yaml
     with:

--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -65,7 +65,7 @@ on:
         description: 'JDK version to use'
         required: true
         type: string
-        default: '17'
+        default: '21'
       endpoint_prefix:
         description: 'Endpoint to prepend specs paths with'
         required: true

--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -92,6 +92,7 @@ jobs:
       version: ${{ inputs.sdk_version }}
       namespace: ${{ inputs.sdk_namespace }}
       endpoint_prefix: ${{ inputs.endpoint_prefix }}
+
     secrets: inherit
   run-rapid-examples:
     if: always() && !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled')
@@ -101,6 +102,7 @@ jobs:
       sdk_version: ${{ needs.generate-test-sdk.outputs.version }}
       jdk: ${{ inputs.jdk }}
       sdk_generation_workflow_run_id: ${{ github.run_id }}
+      specs_url: ${{ inputs.specs_url }}
     secrets:
       KEY: ${{ secrets.RAPID_KEY }}
       SECRET: ${{ secrets.RAPID_SECRET }}

--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -97,7 +97,7 @@ jobs:
   run-rapid-examples:
     if: always() && !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled')
     needs: [ generate-test-sdk ]
-    uses: "ExpediaGroup/rapid-java-sdk/.github/workflows/run-examples.yaml@OmarAlJarrah/fix-failing-run-examples-workflow"
+    uses: "ExpediaGroup/rapid-java-sdk/.github/workflows/run-examples.yaml@main"
     with:
       sdk_version: ${{ needs.generate-test-sdk.outputs.version }}
       jdk: ${{ inputs.jdk }}

--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -95,7 +95,7 @@ jobs:
       specs_url: ${{ inputs.specs_url }}
     secrets: inherit
   run-rapid-examples:
-    if: always() && !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled')
+    if: always() && !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled') && inputs.sdk_namespace == 'rapid'
     needs: [ generate-test-sdk ]
     uses: "ExpediaGroup/rapid-java-sdk/.github/workflows/run-examples.yaml@main"
     with:

--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -77,21 +77,21 @@ jobs:
     steps:
       - shell: python -u {0}
         run: |
-          if 'specs' in '${{ github.event.inputs.source }}' and not('${{ github.event.inputs.specs_url }}'):
-            print('::error::Invalid specs URL: ${{ github.event.inputs.specs_url }}')
+          if 'specs' in '${{ inputs.source }}' and not('${{ inputs.specs_url }}'):
+            print('::error::Invalid specs URL: ${{ inputs.specs_url }}')
             exit(1)
 
-          if 'sdk' in '${{ github.event.inputs.source }}' and not('${{ github.event.inputs.sdk_version }}'):
-            print('::error::Invalid SDK version: ${{ github.event.inputs.sdk_version }}')
+          if 'sdk' in '${{ inputs.source }}' and not('${{ inputs.sdk_version }}'):
+            print('::error::Invalid SDK version: ${{ inputs.sdk_version }}')
             exit(1)
   generate-test-sdk:
-    if: ${{ github.event.inputs.source == 'specs' }}
+    if: ${{ inputs.source == 'specs' }}
     needs: [ inputs-validation ]
     uses: ./.github/workflows/generator-test-sdk.yaml
     with:
-      version: ${{ github.event.inputs.sdk_version }}
-      namespace: ${{ github.event.inputs.sdk_namespace }}
-      endpoint_prefix: ${{ github.event.inputs.endpoint_prefix }}
+      version: ${{ inputs.sdk_version }}
+      namespace: ${{ inputs.sdk_namespace }}
+      endpoint_prefix: ${{ inputs.endpoint_prefix }}
     secrets: inherit
   run-rapid-examples:
     if: always() && !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled')
@@ -99,7 +99,7 @@ jobs:
     uses: "ExpediaGroup/rapid-java-sdk/.github/workflows/run-examples.yaml@main"
     with:
       sdk_version: ${{ needs.generate-test-sdk.outputs.version }}
-      jdk: ${{ github.event.inputs.jdk }}
+      jdk: ${{ inputs.jdk }}
       sdk_generation_workflow_run_id: ${{ github.run_id }}
     secrets:
       KEY: ${{ secrets.RAPID_KEY }}

--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -97,7 +97,7 @@ jobs:
   run-rapid-examples:
     if: always() && !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled')
     needs: [ generate-test-sdk ]
-    uses: "ExpediaGroup/rapid-java-sdk/.github/workflows/run-examples.yaml@main"
+    uses: "ExpediaGroup/rapid-java-sdk/.github/workflows/run-examples.yaml@OmarAlJarrah/fix-failing-run-examples-workflow"
     with:
       sdk_version: ${{ needs.generate-test-sdk.outputs.version }}
       jdk: ${{ inputs.jdk }}

--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -1,6 +1,5 @@
 name: Run Tests
 on:
-  push:
   workflow_dispatch:
     inputs:
       source:

--- a/.github/workflows/selfserve-generate.yaml
+++ b/.github/workflows/selfserve-generate.yaml
@@ -63,3 +63,4 @@ jobs:
           path: |
             sdk-repo/generator/openapi/target/sdk
             !sdk-repo/generator/openapi/target/sdk/target
+          overwrite: true


### PR DESCRIPTION
## What does this pull request do?
Adds a separate PR check workflow that utilizes the run-tests workflow. The new action runs `on-push` and triggers the `run-tests.yaml` workflow with a matrix strategy for different JDK versions. 

The action enforces a sequential matrix jobs run, and sets the [overwrite](https://github.com/actions/upload-artifact?tab=readme-ov-file#overwriting-an-artifact) option of upload artifact reusable action to `true`, in order to ensure consistency across different JDK based workflow runs.

  ```yaml
    strategy:
      matrix:
        jdk: [8, 11, 17, 21]
      max-parallel: 1
```
