### PR TITLE
feat: SDK-1405 support self-serve spec transforming

### DIFF
--- a/.github/workflows/selfserve-generate.yaml
+++ b/.github/workflows/selfserve-generate.yaml
@@ -38,7 +38,6 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: ${{ inputs.specs_key }}
-          path: sdk-repo/generator/openapi
 
       - name: Set up JDK 21
         uses: actions/setup-java@v4
@@ -51,9 +50,8 @@ jobs:
           ls ${{ inputs.templates }}
 
       - name: Generate Product SDK
-        working-directory: sdk-repo/generator/openapi
         run: |
-          mvn clean install exec:java "-Dnamespace=${{ inputs.name }}" -DsdkVersion=${{ inputs.version }} "-Dspec=./${{ inputs.specs_key }}.yaml" -DtemplatesDir=./${{ inputs.templates }}
+          mvn -f sdk-repo/generator/openapi clean install exec:java "-Dnamespace=${{ inputs.name }}" -DsdkVersion=${{ inputs.version }} "-Dspec=./${{ inputs.specs_key }}.yaml" -DtemplatesDir=./${{ inputs.templates }}
 
       - name: Install SDK
         working-directory: sdk-repo/generator/openapi/target/sdk

--- a/.github/workflows/selfserve-generate.yaml
+++ b/.github/workflows/selfserve-generate.yaml
@@ -53,7 +53,7 @@ jobs:
       - name: Generate Product SDK
         working-directory: sdk-repo/generator/openapi
         run: |
-          mvn clean install exec:java "-Dnamespace=${{ inputs.name }}" -DsdkVersion=${{ inputs.version }} "-Dspec=./${{ inputs.specs_key }}.yaml" -DtemplatesDir="${{ inputs.templates }}"
+          mvn clean install exec:java "-Dnamespace=${{ inputs.name }}" -DsdkVersion=${{ inputs.version }} "-Dspec=./${{ inputs.specs_key }}.yaml" -DtemplatesDir=./${{ inputs.templates }}
 
       - name: Install SDK
         working-directory: sdk-repo/generator/openapi/target/sdk

--- a/.github/workflows/selfserve-generate.yaml
+++ b/.github/workflows/selfserve-generate.yaml
@@ -46,6 +46,10 @@ jobs:
           java-version: '21'
           distribution: 'temurin'
 
+      - name: Confirm templates exist
+        run: |
+          ls ${{ inputs.templates }}
+
       - name: Generate Product SDK
         working-directory: sdk-repo/generator/openapi
         run: |

--- a/.github/workflows/selfserve-generate.yaml
+++ b/.github/workflows/selfserve-generate.yaml
@@ -45,10 +45,6 @@ jobs:
           java-version: '21'
           distribution: 'temurin'
 
-      - name: Confirm templates exist
-        run: |
-          ls ${{ inputs.templates }}
-
       - name: Generate Product SDK
         run: |
           mvn -f sdk-repo/generator/openapi clean install exec:java "-Dnamespace=${{ inputs.name }}" -DsdkVersion=${{ inputs.version }} "-Dspec=./${{ inputs.specs_key }}.yaml" -DtemplatesDir=./${{ inputs.templates }}

--- a/.github/workflows/selfserve-transform-specs.yaml
+++ b/.github/workflows/selfserve-transform-specs.yaml
@@ -4,15 +4,14 @@ on:
     inputs:
       specs_key:
         description: 'Key to the specs artifact and name (without extension, e.g. specs, the file is expected to have the extension .yaml)'
-        required: true
         type: string
+        default: 'specs'
       transformations:
         description: 'Spec Transformer CLI Configurations'
         type: string
         required: true
       transformed_specs_key:
         description: 'Key to the transformed specs artifact and name (without extension, e.g. tspecs, the file is expected to have the extension .yaml)'
-        required: true
         type: string
         default: 'tspecs'
 

--- a/.github/workflows/selfserve-transform-specs.yaml
+++ b/.github/workflows/selfserve-transform-specs.yaml
@@ -24,7 +24,7 @@ jobs:
           name: ${{ inputs.specs_key }}
 
       - run: |
-          npx --yes -p @expediagroup/spec-transformer cli ${{ inputs.configurations }} -i ${{ inputs.specs_key }}.yaml -o ${{ inputs.transformed_specs_key }}.yaml
+          npx --yes -p @expediagroup/spec-transformer cli ${{ inputs.transformations }} -i ${{ inputs.specs_key }}.yaml -o ${{ inputs.transformed_specs_key }}.yaml
 
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/selfserve-transform-specs.yaml
+++ b/.github/workflows/selfserve-transform-specs.yaml
@@ -1,0 +1,33 @@
+name: Transform Specs
+on:
+  workflow_call:
+    inputs:
+      specs_key:
+        description: 'Key to the specs artifact and name (without extension, e.g. specs, the file is expected to have the extension .yaml)'
+        required: true
+        type: string
+      transformations:
+        description: 'Spec Transformer CLI Configurations'
+        type: string
+        required: true
+      transformed_specs_key:
+        description: 'Key to the transformed specs artifact and name (without extension, e.g. tspecs, the file is expected to have the extension .yaml)'
+        required: true
+        type: string
+        default: 'tspecs'
+
+jobs:
+  transform-specs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: ${{ inputs.specs_key }}
+
+      - run: |
+          npx --yes -p @expediagroup/spec-transformer cli ${{ inputs.configurations }} -i ${{ inputs.specs_key }}.yaml -o ${{ inputs.transformed_specs_key }}.yaml
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: ${{ inputs.transformed_specs_key }}
+          path: ${{ inputs.transformed_specs_key }}.yaml

--- a/generator/openapi/src/main/kotlin/com/expediagroup/sdk/generators/openapi/OpenApiSdkGenerator.kt
+++ b/generator/openapi/src/main/kotlin/com/expediagroup/sdk/generators/openapi/OpenApiSdkGenerator.kt
@@ -87,7 +87,7 @@ class OpenApiSdkGenerator {
                 CodegenConfigurator().apply {
                     setGeneratorName("kotlin")
                     setTemplateDir(templateDir)
-                    setInputSpec("/Users/mabukhlaif/IdeaProjects/expediagroup-java-sdk/specs.yaml")
+                    setInputSpec(inputFile)
                     setOutputDir(outputDirectory)
                     setArtifactId(product.artifactId)
                     setArtifactVersion(version)

--- a/generator/openapi/src/main/kotlin/com/expediagroup/sdk/generators/openapi/OpenApiSdkGenerator.kt
+++ b/generator/openapi/src/main/kotlin/com/expediagroup/sdk/generators/openapi/OpenApiSdkGenerator.kt
@@ -87,7 +87,7 @@ class OpenApiSdkGenerator {
                 CodegenConfigurator().apply {
                     setGeneratorName("kotlin")
                     setTemplateDir(templateDir)
-                    setInputSpec(inputFile)
+                    setInputSpec("/Users/mabukhlaif/IdeaProjects/expediagroup-java-sdk/specs.yaml")
                     setOutputDir(outputDirectory)
                     setArtifactId(product.artifactId)
                     setArtifactVersion(version)


### PR DESCRIPTION
- add a new GH action template to be used by product SDKs to transform their specs.
- update the generate SDK action template to receive the templates path relative to the root path from the caller side.


An example (draft) action that uses this self-served generation and spec transformation capabilities is available [here](https://github.com/mohnoor94/sdk-generator-user/blob/main/.github/workflows/generate-sdk.yaml) with a successful run available [here](https://github.com/mohnoor94/sdk-generator-user/actions/runs/10287112818).

Internal Ticket: SDK-1405