### PR TITLE
feat: SDK-1407 support self-serve sdk release

### DIFF
--- a/.github/workflows/selfserve-release.yaml
+++ b/.github/workflows/selfserve-release.yaml
@@ -1,0 +1,42 @@
+name: Release an SDK to Maven Central
+
+on:
+  workflow_call:
+    inputs:
+      sdk_key:
+        description: 'Key to the generated SDK artifact'
+        default: 'sdk'
+        type: string
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+          server-id: oss-sonatype
+          server-username: SONATYPE_USERNAME
+          server-password: SONATYPE_PASSWORD
+          gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
+          gpg-passphrase: GPG_PASSPHRASE
+          settings-path: ${{ github.workspace }}
+
+      - name: Download SDK Artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ inputs.sdk_key }}
+          path: sdk
+
+      - name: Release SDK
+        working-directory: sdk
+        env:
+          SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
+          SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
+          GPG_PASSPHRASE: ${{ secrets.GPG_PRIVATE_KEY_PASSPHRASE }}
+        run: |
+          echo "Starting SDK Release - version=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)"
+          mvn deploy --settings $GITHUB_WORKSPACE/settings.xml -B -U -P release -DskipTests=true
+          echo "SDK Released"

--- a/generator/openapi/src/main/resources/templates/expediagroup-sdk/pom.mustache
+++ b/generator/openapi/src/main/resources/templates/expediagroup-sdk/pom.mustache
@@ -395,12 +395,6 @@
 
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-resources-plugin</artifactId>
-                <version>${maven-resources-plugin.version}</version>
-            </plugin>
-
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>${maven-compiler-plugin.version}</version>
                 <configuration>


### PR DESCRIPTION
- add a new GH action template to be used by product SDKs to publish the generated SDKs to Maven central.
- fix a duplicate dependency in the generated pom file.

An example (draft) action that uses this self-served generation and spec transformation capabilities is available [here](https://github.com/mohnoor94/sdk-generator-user/blob/main/.github/workflows/generate-sdk.yaml).

Internal Ticket: SDK-1407