### PR TITLE
fix(security): SDK-1509 prevent command injection in PR title validation workflow

### DIFF
--- a/.github/workflows/contribution-lint.yaml
+++ b/.github/workflows/contribution-lint.yaml
@@ -34,6 +34,8 @@ jobs:
       - name: Install Dependencies
         run: npm install
       - name: Run Pull Request Title Validation
-        run: echo "${{ github.event.pull_request.title }}" | npx commitlint --config commitlint.config.js --verbose
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: npx commitlint --config commitlint.config.js --verbose <<< "$PR_TITLE"
       - name: Run Latest Commit Message Validation
         run: git log -1 --no-merges --pretty=format:"%s" | npx commitlint --config commitlint.config.js --verbose


### PR DESCRIPTION
# Situation
A security vulnerability was identified in the PR title validation workflow where malicious PR titles could execute arbitrary commands on the Actions runner.

# Task
Fix command injection vulnerability while maintaining PR title validation functionality.

# Action
Changed PR title handling to use environment variables:
```yaml
env:
  PR_TITLE: ${{ github.event.pull_request.title }}
run: npx commitlint --config commitlint.config.js --verbose <<< "$PR_TITLE"
```

# Testing
- Verified with normal PR titles
- Tested with command injection payloads
- Confirmed commitlint still works as expected

# Results
- Blocked command injection vulnerability
- Maintained existing PR title validation
- No workflow disruption

# Notes
Security improvement that prevents privilege escalation through PR title manipulation.