### PR TITLE
feat: SDK-1568 expose okhttp client as a configuration in sdk core

### DIFF
--- a/core/src/main/kotlin/com/expediagroup/sdk/core/client/BaseRapidClient.kt
+++ b/core/src/main/kotlin/com/expediagroup/sdk/core/client/BaseRapidClient.kt
@@ -22,6 +22,8 @@ import com.expediagroup.sdk.core.configuration.provider.RapidConfigurationProvid
 import com.expediagroup.sdk.core.plugin.authentication.strategy.AuthenticationStrategy
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.HttpClientEngine
+import io.ktor.client.engine.okhttp.OkHttp
+import okhttp3.OkHttpClient
 
 /**
  * The integration point between the SDK Core and the product SDKs.
@@ -39,7 +41,15 @@ abstract class BaseRapidClient(
             clientConfiguration.toProvider(),
             RapidConfigurationProvider
         )
-    private val _httpClient: HttpClient = buildHttpClient(_configurationProvider, AuthenticationStrategy.AuthenticationType.SIGNATURE, httpClientEngine)
+
+    private val _httpClientEngine: HttpClientEngine = clientConfiguration.okHttpClient?.let {
+
+        OkHttp.create {
+            preconfigured = it
+        }
+    } ?: httpClientEngine
+
+    private val _httpClient: HttpClient = buildHttpClient(_configurationProvider, AuthenticationStrategy.AuthenticationType.SIGNATURE, _httpClientEngine)
 
     init {
         finalize()
@@ -53,5 +63,23 @@ abstract class BaseRapidClient(
 
     /** A [BaseRapidClient] builder. */
     @Suppress("unused", "UnnecessaryAbstractClass") // This is used by the generated SDK clients.
-    abstract class Builder<SELF : Builder<SELF>> : Client.Builder<SELF>()
+    abstract class Builder<SELF : Builder<SELF>> : BuilderExtension<SELF>()
+
+    /** A [BaseRapidClient] builder with ability to pass a custom okhttp client. */
+    @Suppress("unused", "UnnecessaryAbstractClass") // This is used by the generated SDK clients.
+    abstract class BuilderWithHttpClient<SELF : Client.Builder<SELF>> : Client.Builder<SELF>() {
+
+        protected var okHttpClient: OkHttpClient? = null
+
+        override fun self(): SELF {
+            return this as SELF
+        }
+
+        /** Sets the [OkHttpClient] to use for the [BaseRapidClient]. */
+        fun okHttpClient(okHttpClient: OkHttpClient): SELF {
+            this.okHttpClient = okHttpClient
+            return self()
+        }
+
+    }
 }

--- a/core/src/main/kotlin/com/expediagroup/sdk/core/client/BaseRapidClient.kt
+++ b/core/src/main/kotlin/com/expediagroup/sdk/core/client/BaseRapidClient.kt
@@ -42,14 +42,13 @@ abstract class BaseRapidClient(
             RapidConfigurationProvider
         )
 
-    private val _httpClientEngine: HttpClientEngine = clientConfiguration.okHttpClient?.let {
-
+    private val httpClientEngine: HttpClientEngine = clientConfiguration.okHttpClient?.let {
         OkHttp.create {
             preconfigured = it
         }
     } ?: httpClientEngine
 
-    private val _httpClient: HttpClient = buildHttpClient(_configurationProvider, AuthenticationStrategy.AuthenticationType.SIGNATURE, _httpClientEngine)
+    private val _httpClient: HttpClient = buildHttpClient(_configurationProvider, AuthenticationStrategy.AuthenticationType.SIGNATURE, httpClientEngine)
 
     init {
         finalize()
@@ -63,17 +62,15 @@ abstract class BaseRapidClient(
 
     /** A [BaseRapidClient] builder. */
     @Suppress("unused", "UnnecessaryAbstractClass") // This is used by the generated SDK clients.
-    abstract class Builder<SELF : Builder<SELF>> : BuilderExtension<SELF>()
+    abstract class Builder<SELF : Builder<SELF>> : HttpConfigurableBuilder<SELF>()
 
     /** A [BaseRapidClient] builder with ability to pass a custom okhttp client. */
     @Suppress("unused", "UnnecessaryAbstractClass") // This is used by the generated SDK clients.
     abstract class BuilderWithHttpClient<SELF : Client.Builder<SELF>> : Client.Builder<SELF>() {
-
         protected var okHttpClient: OkHttpClient? = null
 
-        override fun self(): SELF {
-            return this as SELF
-        }
+        @Suppress("UNCHECKED_CAST")
+        override fun self(): SELF = this as SELF
 
         /** Sets the [OkHttpClient] to use for the [BaseRapidClient]. */
         fun okHttpClient(okHttpClient: OkHttpClient): SELF {

--- a/core/src/main/kotlin/com/expediagroup/sdk/core/client/BaseRapidClient.kt
+++ b/core/src/main/kotlin/com/expediagroup/sdk/core/client/BaseRapidClient.kt
@@ -23,7 +23,6 @@ import com.expediagroup.sdk.core.plugin.authentication.strategy.AuthenticationSt
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.HttpClientEngine
 import io.ktor.client.engine.okhttp.OkHttp
-import okhttp3.OkHttpClient
 
 /**
  * The integration point between the SDK Core and the product SDKs.
@@ -42,7 +41,7 @@ abstract class BaseRapidClient(
             RapidConfigurationProvider
         )
 
-    private val engine: HttpClientEngine = clientConfiguration.okHttpClient?.let {
+    private val engine: HttpClientEngine = _configurationProvider.okHttpClient?.let {
         OkHttp.create {
             preconfigured = it
         }
@@ -66,17 +65,5 @@ abstract class BaseRapidClient(
 
     /** A [BaseRapidClient] builder with ability to pass a custom okhttp client. */
     @Suppress("unused", "UnnecessaryAbstractClass") // This is used by the generated SDK clients.
-    abstract class BuilderWithHttpClient<SELF : Client.Builder<SELF>> : Client.Builder<SELF>() {
-        protected var okHttpClient: OkHttpClient? = null
-
-        @Suppress("UNCHECKED_CAST")
-        override fun self(): SELF = this as SELF
-
-        /** Sets the [OkHttpClient] to use for the [BaseRapidClient]. */
-        fun okHttpClient(okHttpClient: OkHttpClient): SELF {
-            this.okHttpClient = okHttpClient
-            return self()
-        }
-
-    }
+    abstract class BuilderWithHttpClient<SELF : Client.BuilderWithHttpClient<SELF>> : Client.BuilderWithHttpClient<SELF>()
 }

--- a/core/src/main/kotlin/com/expediagroup/sdk/core/client/BaseRapidClient.kt
+++ b/core/src/main/kotlin/com/expediagroup/sdk/core/client/BaseRapidClient.kt
@@ -42,13 +42,13 @@ abstract class BaseRapidClient(
             RapidConfigurationProvider
         )
 
-    private val httpClientEngine: HttpClientEngine = clientConfiguration.okHttpClient?.let {
+    private val engine: HttpClientEngine = clientConfiguration.okHttpClient?.let {
         OkHttp.create {
             preconfigured = it
         }
     } ?: httpClientEngine
 
-    private val _httpClient: HttpClient = buildHttpClient(_configurationProvider, AuthenticationStrategy.AuthenticationType.SIGNATURE, httpClientEngine)
+    private val _httpClient: HttpClient = buildHttpClient(_configurationProvider, AuthenticationStrategy.AuthenticationType.SIGNATURE, engine)
 
     init {
         finalize()

--- a/core/src/main/kotlin/com/expediagroup/sdk/core/client/BaseXapClient.kt
+++ b/core/src/main/kotlin/com/expediagroup/sdk/core/client/BaseXapClient.kt
@@ -23,7 +23,6 @@ import com.expediagroup.sdk.core.plugin.authentication.strategy.AuthenticationSt
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.HttpClientEngine
 import io.ktor.client.engine.okhttp.OkHttp
-import okhttp3.OkHttpClient
 
 /**
  * The integration point between the SDK Core and the product SDKs.
@@ -42,7 +41,7 @@ abstract class BaseXapClient(
             XapConfigurationProvider
         )
 
-    private val engine: HttpClientEngine = clientConfiguration.okHttpClient?.let {
+    private val engine: HttpClientEngine = _configurationProvider.okHttpClient?.let {
         OkHttp.create {
             preconfigured = it
         }
@@ -66,17 +65,5 @@ abstract class BaseXapClient(
 
     /** A [BaseXapClient] builder with ability to pass a custom okhttp client. */
     @Suppress("unused", "UnnecessaryAbstractClass") // This is used by the generated SDK clients.
-    abstract class BuilderWithHttpClient<SELF : Client.Builder<SELF>> : Client.Builder<SELF>() {
-        protected var okHttpClient: OkHttpClient? = null
-
-        @Suppress("UNCHECKED_CAST")
-        override fun self(): SELF = this as SELF
-
-        /** Sets the [OkHttpClient] to use for the [BaseXapClient]. */
-        fun okHttpClient(okHttpClient: OkHttpClient): SELF {
-            this.okHttpClient = okHttpClient
-            return self()
-        }
-
-    }
+    abstract class BuilderWithHttpClient<SELF : Client.BuilderWithHttpClient<SELF>> : Client.BuilderWithHttpClient<SELF>()
 }

--- a/core/src/main/kotlin/com/expediagroup/sdk/core/client/BaseXapClient.kt
+++ b/core/src/main/kotlin/com/expediagroup/sdk/core/client/BaseXapClient.kt
@@ -53,5 +53,5 @@ abstract class BaseXapClient(
 
     /** A [BaseXapClient] builder. */
     @Suppress("unused", "UnnecessaryAbstractClass") // This is used by the generated SDK clients.
-    abstract class Builder<SELF : Builder<SELF>> : Client.Builder<SELF>()
+    abstract class Builder<SELF : Builder<SELF>> : BuilderExtension<SELF>()
 }

--- a/core/src/main/kotlin/com/expediagroup/sdk/core/client/BaseXapClient.kt
+++ b/core/src/main/kotlin/com/expediagroup/sdk/core/client/BaseXapClient.kt
@@ -22,7 +22,8 @@ import com.expediagroup.sdk.core.configuration.provider.XapConfigurationProvider
 import com.expediagroup.sdk.core.plugin.authentication.strategy.AuthenticationStrategy
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.HttpClientEngine
-import io.ktor.client.engine.okhttp.*
+import io.ktor.client.engine.okhttp.OkHttp
+import okhttp3.OkHttpClient
 
 /**
  * The integration point between the SDK Core and the product SDKs.
@@ -62,4 +63,20 @@ abstract class BaseXapClient(
     /** A [BaseXapClient] builder. */
     @Suppress("unused", "UnnecessaryAbstractClass") // This is used by the generated SDK clients.
     abstract class Builder<SELF : Builder<SELF>> : HttpConfigurableBuilder<SELF>()
+
+    /** A [BaseXapClient] builder with ability to pass a custom okhttp client. */
+    @Suppress("unused", "UnnecessaryAbstractClass") // This is used by the generated SDK clients.
+    abstract class BuilderWithHttpClient<SELF : Client.Builder<SELF>> : Client.Builder<SELF>() {
+        protected var okHttpClient: OkHttpClient? = null
+
+        @Suppress("UNCHECKED_CAST")
+        override fun self(): SELF = this as SELF
+
+        /** Sets the [OkHttpClient] to use for the [BaseXapClient]. */
+        fun okHttpClient(okHttpClient: OkHttpClient): SELF {
+            this.okHttpClient = okHttpClient
+            return self()
+        }
+
+    }
 }

--- a/core/src/main/kotlin/com/expediagroup/sdk/core/client/BaseXapClient.kt
+++ b/core/src/main/kotlin/com/expediagroup/sdk/core/client/BaseXapClient.kt
@@ -22,6 +22,7 @@ import com.expediagroup.sdk.core.configuration.provider.XapConfigurationProvider
 import com.expediagroup.sdk.core.plugin.authentication.strategy.AuthenticationStrategy
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.HttpClientEngine
+import io.ktor.client.engine.okhttp.*
 
 /**
  * The integration point between the SDK Core and the product SDKs.
@@ -39,7 +40,14 @@ abstract class BaseXapClient(
             clientConfiguration.toProvider(),
             XapConfigurationProvider
         )
-    private val _httpClient: HttpClient = buildHttpClient(_configurationProvider, AuthenticationStrategy.AuthenticationType.BASIC, httpClientEngine)
+
+    private val engine: HttpClientEngine = clientConfiguration.okHttpClient?.let {
+        OkHttp.create {
+            preconfigured = it
+        }
+    } ?: httpClientEngine
+
+    private val _httpClient: HttpClient = buildHttpClient(_configurationProvider, AuthenticationStrategy.AuthenticationType.BASIC, engine)
 
     init {
         finalize()

--- a/core/src/main/kotlin/com/expediagroup/sdk/core/client/BaseXapClient.kt
+++ b/core/src/main/kotlin/com/expediagroup/sdk/core/client/BaseXapClient.kt
@@ -53,5 +53,5 @@ abstract class BaseXapClient(
 
     /** A [BaseXapClient] builder. */
     @Suppress("unused", "UnnecessaryAbstractClass") // This is used by the generated SDK clients.
-    abstract class Builder<SELF : Builder<SELF>> : BuilderExtension<SELF>()
+    abstract class Builder<SELF : Builder<SELF>> : HttpConfigurableBuilder<SELF>()
 }

--- a/core/src/main/kotlin/com/expediagroup/sdk/core/client/Client.kt
+++ b/core/src/main/kotlin/com/expediagroup/sdk/core/client/Client.kt
@@ -51,6 +51,7 @@ import io.ktor.client.engine.okhttp.OkHttp
 import io.ktor.client.statement.HttpResponse
 import io.ktor.client.statement.request
 import okhttp3.Dispatcher
+import okhttp3.OkHttpClient
 
 // Create a Dispatcher with limits
 val dispatcher = Dispatcher().apply {
@@ -309,12 +310,30 @@ abstract class Client(
 
         /** Create a [Client] object. */
         abstract override fun build(): Client
-
     }
 
+
+    /**
+     * A builder class for configuring HTTP-related settings for a [Client] with the ability to pass a custom [OkHttpClient].
+     *
+     * This builder class extends the base [Client.Builder] class and provides additional methods
+     * for setting a configured okhttp client.
+     *
+     * @param <SELF> The type of the builder itself, used for method chaining.
+     */
+    abstract class BuilderWithHttpClient<SELF : Builder<SELF>> : Builder<SELF>() {
+        protected var okHttpClient: OkHttpClient? = null
+
+        @Suppress("UNCHECKED_CAST")
+        override fun self(): SELF = this as SELF
+
+        /** Sets the [OkHttpClient] to use for the [Client]. */
+        fun okHttpClient(okHttpClient: OkHttpClient): SELF {
+            this.okHttpClient = okHttpClient
+            return self()
+        }
+    }
 }
 
 /** Executes the hooks for the client. */
 fun <T : Client> T.finalize() = Hooks.execute(this)
-
-

--- a/core/src/main/kotlin/com/expediagroup/sdk/core/client/Client.kt
+++ b/core/src/main/kotlin/com/expediagroup/sdk/core/client/Client.kt
@@ -61,7 +61,7 @@ val dispatcher = Dispatcher().apply {
 val DEFAULT_HTTP_CLIENT_ENGINE: HttpClientEngine =
     OkHttp.create {
         config {
-            eventListener(OkHttpEventListener)
+            eventListenerFactory(OkHttpEventListener.FACTORY)
             dispatcher(dispatcher)
         }
     }
@@ -147,7 +147,7 @@ abstract class Client(
     suspend fun performGet(url: String): HttpResponse = httpHandler.performGet(httpClient, url)
 
     /**
-     * A [Client] builder.
+     * A [Client] base builder.
      */
     abstract class Builder<SELF : Builder<SELF>> {
         /** Sets the API key to use for authentication. */
@@ -158,33 +158,6 @@ abstract class Client(
 
         /** Sets the API endpoint to use for requests. */
         protected var endpoint: String? = null
-
-        /**
-         * Sets the request timeout in milliseconds.
-         *
-         * Request timeout is the time period from the start of the request to the completion of the response.
-         *
-         * Default is infinite - no timeout.
-         */
-        protected var requestTimeout: Long? = null
-
-        /**
-         * Sets the connection timeout in milliseconds.
-         *
-         * Connection timeout is the time period from the start of the request to the establishment of the connection with the server.
-         *
-         * Default is 10 seconds (10000 milliseconds).
-         */
-        protected var connectionTimeout: Long? = null
-
-        /**
-         * Sets the socket timeout in milliseconds.
-         *
-         * Socket timeout is the maximum period of inactivity between two consecutive data packets.
-         *
-         * Default is 15 seconds (15000 milliseconds).
-         */
-        protected var socketTimeout: Long? = null
 
         /** Sets tne body fields to be masked in logging. */
         protected var maskedLoggingHeaders: Set<String>? = null
@@ -222,6 +195,70 @@ abstract class Client(
             log.info(LoggingMessageProvider.getRuntimeConfigurationProviderMessage(ConfigurationName.ENDPOINT, endpoint))
             return self()
         }
+
+        /**
+         * Sets tne headers to be masked in logging.
+         *
+         * @param headers the headers to be masked in logging.
+         * @return The [Builder] instance.
+         */
+        fun maskedLoggingHeaders(vararg headers: String): SELF {
+            this.maskedLoggingHeaders = headers.toSet()
+            log.info(LoggingMessageProvider.getRuntimeConfigurationProviderMessage(ConfigurationName.MASKED_LOGGING_HEADERS, headers.joinToString()))
+            return self()
+        }
+
+        /**
+         * Sets tne body fields to be masked in logging.
+         *
+         * @param fields the body fields to be masked in logging.
+         * @return The [Builder] instance.
+         */
+        fun maskedLoggingBodyFields(vararg fields: String): SELF {
+            this.maskedLoggingBodyFields = fields.toSet()
+            log.info(LoggingMessageProvider.getRuntimeConfigurationProviderMessage(ConfigurationName.MASKED_LOGGING_BODY_FIELDS, fields.joinToString()))
+            return self()
+        }
+
+        /** Create a [Client] object. */
+        abstract fun build(): Client
+
+        @Suppress("UNCHECKED_CAST") // This is safe because of the type parameter
+        protected open fun self(): SELF = this as SELF
+    }
+
+
+    /**
+     * A [Client] extension builder.
+     */
+    abstract class BuilderExtension<SELF : Builder<SELF>> : Builder<SELF>() {
+
+        /**
+         * Sets the request timeout in milliseconds.
+         *
+         * Request timeout is the time period from the start of the request to the completion of the response.
+         *
+         * Default is infinite - no timeout.
+         */
+        protected var requestTimeout: Long? = null
+
+        /**
+         * Sets the connection timeout in milliseconds.
+         *
+         * Connection timeout is the time period from the start of the request to the establishment of the connection with the server.
+         *
+         * Default is 10 seconds (10000 milliseconds).
+         */
+        protected var connectionTimeout: Long? = null
+
+        /**
+         * Sets the socket timeout in milliseconds.
+         *
+         * Socket timeout is the maximum period of inactivity between two consecutive data packets.
+         *
+         * Default is 15 seconds (15000 milliseconds).
+         */
+        protected var socketTimeout: Long? = null
 
         /**
          * Sets the request timeout in milliseconds.
@@ -265,37 +302,14 @@ abstract class Client(
             return self()
         }
 
-        /**
-         * Sets tne headers to be masked in logging.
-         *
-         * @param headers the headers to be masked in logging.
-         * @return The [Builder] instance.
-         */
-        fun maskedLoggingHeaders(vararg headers: String): SELF {
-            this.maskedLoggingHeaders = headers.toSet()
-            log.info(LoggingMessageProvider.getRuntimeConfigurationProviderMessage(ConfigurationName.MASKED_LOGGING_HEADERS, headers.joinToString()))
-            return self()
-        }
-
-        /**
-         * Sets tne body fields to be masked in logging.
-         *
-         * @param fields the body fields to be masked in logging.
-         * @return The [Builder] instance.
-         */
-        fun maskedLoggingBodyFields(vararg fields: String): SELF {
-            this.maskedLoggingBodyFields = fields.toSet()
-            log.info(LoggingMessageProvider.getRuntimeConfigurationProviderMessage(ConfigurationName.MASKED_LOGGING_BODY_FIELDS, fields.joinToString()))
-            return self()
-        }
-
         /** Create a [Client] object. */
-        abstract fun build(): Client
+        abstract override fun build(): Client
 
-        @Suppress("UNCHECKED_CAST") // This is safe because of the type parameter
-        protected open fun self(): SELF = this as SELF
     }
+
 }
 
 /** Executes the hooks for the client. */
 fun <T : Client> T.finalize() = Hooks.execute(this)
+
+

--- a/core/src/main/kotlin/com/expediagroup/sdk/core/client/Client.kt
+++ b/core/src/main/kotlin/com/expediagroup/sdk/core/client/Client.kt
@@ -229,9 +229,14 @@ abstract class Client(
 
 
     /**
-     * A [Client] extension builder.
+     * A builder class for configuring HTTP-related settings for a [Client].
+     *
+     * This builder class extends the base [Client.Builder] class and provides additional methods
+     * for configuring HTTP-specific settings such as request timeout, connection timeout, and socket timeout.
+     *
+     * @param <SELF> The type of the builder itself, used for method chaining.
      */
-    abstract class BuilderExtension<SELF : Builder<SELF>> : Builder<SELF>() {
+    abstract class HttpConfigurableBuilder<SELF : Builder<SELF>> : Builder<SELF>() {
 
         /**
          * Sets the request timeout in milliseconds.

--- a/core/src/main/kotlin/com/expediagroup/sdk/core/client/ExpediaGroupClient.kt
+++ b/core/src/main/kotlin/com/expediagroup/sdk/core/client/ExpediaGroupClient.kt
@@ -53,7 +53,7 @@ abstract class ExpediaGroupClient(
 
     /** An [ExpediaGroupClient] builder. */
     @Suppress("unused") // This is used by the generated SDK clients.
-    abstract class Builder<SELF : Builder<SELF>> : BuilderExtension<SELF>() {
+    abstract class Builder<SELF : Builder<SELF>> : HttpConfigurableBuilder<SELF>() {
         /** Sets the API auth endpoint to use for requests. */
         protected var authEndpoint: String? = null
 

--- a/core/src/main/kotlin/com/expediagroup/sdk/core/client/ExpediaGroupClient.kt
+++ b/core/src/main/kotlin/com/expediagroup/sdk/core/client/ExpediaGroupClient.kt
@@ -53,7 +53,7 @@ abstract class ExpediaGroupClient(
 
     /** An [ExpediaGroupClient] builder. */
     @Suppress("unused") // This is used by the generated SDK clients.
-    abstract class Builder<SELF : Builder<SELF>> : Client.Builder<SELF>() {
+    abstract class Builder<SELF : Builder<SELF>> : BuilderExtension<SELF>() {
         /** Sets the API auth endpoint to use for requests. */
         protected var authEndpoint: String? = null
 

--- a/core/src/main/kotlin/com/expediagroup/sdk/core/client/OkHttpEventListener.kt
+++ b/core/src/main/kotlin/com/expediagroup/sdk/core/client/OkHttpEventListener.kt
@@ -39,7 +39,7 @@ import java.util.concurrent.atomic.AtomicReference
  *
  * @property transactionId A reference to the unique transaction ID associated with the HTTP call.
  */
-class OkHttpEventListener private constructor(private val transactionId: AtomicReference<UUID>) : EventListener() {
+class OkHttpEventListener private constructor(private val transactionId: AtomicReference<String>) : EventListener() {
 
     private val log = ExpediaGroupLoggerFactory.getLogger(this::class.java)
 
@@ -47,7 +47,7 @@ class OkHttpEventListener private constructor(private val transactionId: AtomicR
         val FACTORY: Factory =
             Factory { call ->
                 val transactionIdHeader = call.request().header(HeaderKey.TRANSACTION_ID)
-                val transactionId = AtomicReference(UUID.fromString(transactionIdHeader))
+                val transactionId = AtomicReference(transactionIdHeader.toString())
                 OkHttpEventListener(transactionId)
             }
     }

--- a/core/src/main/kotlin/com/expediagroup/sdk/core/client/OkHttpEventListener.kt
+++ b/core/src/main/kotlin/com/expediagroup/sdk/core/client/OkHttpEventListener.kt
@@ -27,7 +27,6 @@ import okhttp3.EventListener
 import java.io.IOException
 import java.net.InetSocketAddress
 import java.net.Proxy
-import java.util.UUID
 import java.util.concurrent.atomic.AtomicReference
 
 /**

--- a/core/src/main/kotlin/com/expediagroup/sdk/core/client/OkHttpEventListener.kt
+++ b/core/src/main/kotlin/com/expediagroup/sdk/core/client/OkHttpEventListener.kt
@@ -30,30 +30,36 @@ import java.net.Proxy
 import java.util.UUID
 import java.util.concurrent.atomic.AtomicReference
 
-data class OkHttpEventListener private constructor(private val transactionId: AtomicReference<UUID>) : EventListener() {
+/**
+ * An `EventListener` implementation for OkHttp that logs various events during the lifecycle of an HTTP call.
+ *
+ * This listener logs events such as call start, call end, connection start, connection end, request headers start,
+ * request headers end, request body start, request body end, response headers start, response headers end,
+ * response body start, response body end, and failures.
+ *
+ * @property transactionId A reference to the unique transaction ID associated with the HTTP call.
+ */
+class OkHttpEventListener private constructor(private val transactionId: AtomicReference<UUID>) : EventListener() {
 
     private val log = ExpediaGroupLoggerFactory.getLogger(this::class.java)
 
-    // Factory for creating EventListeners with transaction IDs
     companion object {
-        // Expose the factory as a static property
-        val FACTORY: EventListener.Factory = object : EventListener.Factory {
-            override fun create(call: Call): EventListener {
+        val FACTORY: Factory =
+            Factory { call ->
                 val transactionIdHeader = call.request().header(HeaderKey.TRANSACTION_ID)
                 val transactionId = AtomicReference(UUID.fromString(transactionIdHeader))
-                return OkHttpEventListener(transactionId)
+                OkHttpEventListener(transactionId)
             }
-        }
     }
 
     override fun callStart(call: Call) {
         super.callStart(call)
-        log.debug("Call start for transaction-id: [${transactionId.get()}]")
+        log.debug("Call start for transaction-id: [{}]", transactionId.get())
     }
 
     override fun callEnd(call: Call) {
         super.callEnd(call)
-        log.debug("Call end for transaction-id: [${transactionId.get()}]")
+        log.debug("Call end for transaction-id: [{}]", transactionId.get())
     }
 
     override fun callFailed(
@@ -61,12 +67,12 @@ data class OkHttpEventListener private constructor(private val transactionId: At
         ioe: IOException
     ) {
         super.callFailed(call, ioe)
-        log.debug("Call failed for transaction-id: [${transactionId.get()}] with exception message: ${ioe.message}")
+        log.debug("Call failed for transaction-id: [{}] with exception message: {}", transactionId.get(), ioe.message)
     }
 
     override fun canceled(call: Call) {
         super.canceled(call)
-        log.debug("Call canceled for transaction-id: [${transactionId.get()}]")
+        log.debug("Call canceled for transaction-id: [{}]", transactionId.get())
     }
 
     override fun connectStart(
@@ -75,7 +81,7 @@ data class OkHttpEventListener private constructor(private val transactionId: At
         proxy: Proxy
     ) {
         super.connectStart(call, inetSocketAddress, proxy)
-        log.debug("Connect start for transaction-id: [${transactionId.get()}]")
+        log.debug("Connect start for transaction-id: [{}]", transactionId.get())
     }
 
     override fun connectEnd(
@@ -85,7 +91,7 @@ data class OkHttpEventListener private constructor(private val transactionId: At
         protocol: Protocol?
     ) {
         super.connectEnd(call, inetSocketAddress, proxy, protocol)
-        log.debug("Connect end for transaction-id: [${transactionId.get()}]")
+        log.debug("Connect end for transaction-id: [{}]", transactionId.get())
     }
 
     override fun connectFailed(
@@ -96,7 +102,7 @@ data class OkHttpEventListener private constructor(private val transactionId: At
         ioe: IOException
     ) {
         super.connectFailed(call, inetSocketAddress, proxy, protocol, ioe)
-        log.debug("Connect failed for transaction-id: [${transactionId.get()}] with exception message: ${ioe.message}")
+        log.debug("Connect failed for transaction-id: [{}] with exception message: {}", transactionId.get(), ioe.message)
     }
 
     override fun connectionAcquired(
@@ -104,7 +110,7 @@ data class OkHttpEventListener private constructor(private val transactionId: At
         connection: Connection
     ) {
         super.connectionAcquired(call, connection)
-        log.debug("Connection acquired for transaction-id: [${transactionId.get()}]")
+        log.debug("Connection acquired for transaction-id: [{}]", transactionId.get())
     }
 
     override fun connectionReleased(
@@ -112,12 +118,12 @@ data class OkHttpEventListener private constructor(private val transactionId: At
         connection: Connection
     ) {
         super.connectionReleased(call, connection)
-        log.debug("Connection released for transaction-id: [${transactionId.get()}]")
+        log.debug("Connection released for transaction-id: [{}]", transactionId.get())
     }
 
     override fun secureConnectStart(call: Call) {
         super.secureConnectStart(call)
-        log.debug("Secure connect start for transaction-id: [${transactionId.get()}]")
+        log.debug("Secure connect start for transaction-id: [{}]", transactionId.get())
     }
 
     override fun secureConnectEnd(
@@ -125,12 +131,12 @@ data class OkHttpEventListener private constructor(private val transactionId: At
         handshake: Handshake?
     ) {
         super.secureConnectEnd(call, handshake)
-        log.debug("Secure connect end for transaction-id: [${transactionId.get()}]")
+        log.debug("Secure connect end for transaction-id: [{}]", transactionId.get())
     }
 
     override fun requestHeadersStart(call: Call) {
         super.requestHeadersStart(call)
-        log.debug("Sending request headers start for transaction-id: [${transactionId.get()}]")
+        log.debug("Sending request headers start for transaction-id: [{}]", transactionId.get())
     }
 
     override fun requestHeadersEnd(
@@ -138,12 +144,12 @@ data class OkHttpEventListener private constructor(private val transactionId: At
         request: Request
     ) {
         super.requestHeadersEnd(call, request)
-        log.debug("Sending request headers end for transaction-id: [${transactionId.get()}]")
+        log.debug("Sending request headers end for transaction-id: [{}]", transactionId.get())
     }
 
     override fun requestBodyStart(call: Call) {
         super.requestBodyStart(call)
-        log.debug("Sending request body start for transaction-id: [${transactionId.get()}]")
+        log.debug("Sending request body start for transaction-id: [{}]", transactionId.get())
     }
 
     override fun requestBodyEnd(
@@ -151,7 +157,7 @@ data class OkHttpEventListener private constructor(private val transactionId: At
         byteCount: Long
     ) {
         super.requestBodyEnd(call, byteCount)
-        log.debug("Sending request body end for transaction-id: [${transactionId.get()}] with byte count: $byteCount")
+        log.debug("Sending request body end for transaction-id: [{}] with byte count: {}", transactionId.get(), byteCount)
     }
 
     override fun requestFailed(
@@ -159,12 +165,12 @@ data class OkHttpEventListener private constructor(private val transactionId: At
         ioe: IOException
     ) {
         super.requestFailed(call, ioe)
-        log.debug("Request failed for transaction-id: [${transactionId.get()}] with exception message: ${ioe.message}")
+        log.debug("Request failed for transaction-id: [{}] with exception message: {}", transactionId.get(), ioe.message)
     }
 
     override fun responseHeadersStart(call: Call) {
         super.responseHeadersStart(call)
-        log.debug("Receiving response headers start for transaction-id: [${transactionId.get()}]")
+        log.debug("Receiving response headers start for transaction-id: [{}]", transactionId.get())
     }
 
     override fun responseHeadersEnd(
@@ -172,12 +178,12 @@ data class OkHttpEventListener private constructor(private val transactionId: At
         response: Response
     ) {
         super.responseHeadersEnd(call, response)
-        log.debug("Receiving response headers end for transaction-id: [${transactionId.get()}]")
+        log.debug("Receiving response headers end for transaction-id: [{}]", transactionId.get())
     }
 
     override fun responseBodyStart(call: Call) {
         super.responseBodyStart(call)
-        log.debug("Receiving response body start for transaction-id: [${transactionId.get()}]")
+        log.debug("Receiving response body start for transaction-id: [{}]", transactionId.get())
     }
 
     override fun responseBodyEnd(
@@ -185,7 +191,7 @@ data class OkHttpEventListener private constructor(private val transactionId: At
         byteCount: Long
     ) {
         super.responseBodyEnd(call, byteCount)
-        log.debug("Receiving response body end for transaction-id: [${transactionId.get()}] with byte count: $byteCount")
+        log.debug("Receiving response body end for transaction-id: [{}] with byte count: {}", transactionId.get(), byteCount)
     }
 
     override fun responseFailed(
@@ -193,6 +199,6 @@ data class OkHttpEventListener private constructor(private val transactionId: At
         ioe: IOException
     ) {
         super.responseFailed(call, ioe)
-        log.debug("Receiving response failed for transaction-id: [${transactionId.get()}] with exception message: ${ioe.message}")
+        log.debug("Receiving response failed for transaction-id: [{}] with exception message: {}", transactionId.get(), ioe.message)
     }
 }

--- a/core/src/main/kotlin/com/expediagroup/sdk/core/configuration/ClientConfiguration.kt
+++ b/core/src/main/kotlin/com/expediagroup/sdk/core/configuration/ClientConfiguration.kt
@@ -16,6 +16,7 @@
 package com.expediagroup.sdk.core.configuration
 
 import com.expediagroup.sdk.core.configuration.provider.RuntimeConfigurationProvider
+import okhttp3.OkHttpClient
 
 interface ClientConfiguration {
     val key: String?
@@ -26,6 +27,7 @@ interface ClientConfiguration {
     val socketTimeout: Long?
     val maskedLoggingHeaders: Set<String>?
     val maskedLoggingBodyFields: Set<String>?
+    val okHttpClient: OkHttpClient?
 
     /** Build a [RuntimeConfigurationProvider] from a [ClientConfiguration]. */
     fun toProvider(): RuntimeConfigurationProvider =
@@ -37,6 +39,7 @@ interface ClientConfiguration {
             connectionTimeout = connectionTimeout,
             socketTimeout = socketTimeout,
             maskedLoggingHeaders = maskedLoggingHeaders,
-            maskedLoggingBodyFields = maskedLoggingBodyFields
+            maskedLoggingBodyFields = maskedLoggingBodyFields,
+            okHttpClient = okHttpClient
         )
 }

--- a/core/src/main/kotlin/com/expediagroup/sdk/core/configuration/ExpediaGroupClientConfiguration.kt
+++ b/core/src/main/kotlin/com/expediagroup/sdk/core/configuration/ExpediaGroupClientConfiguration.kt
@@ -17,6 +17,7 @@ package com.expediagroup.sdk.core.configuration
 
 import com.expediagroup.sdk.core.client.ExpediaGroupClient
 import com.expediagroup.sdk.core.configuration.provider.RuntimeConfigurationProvider
+import okhttp3.OkHttpClient
 
 /**
  * Configuration for the [ExpediaGroupClient].
@@ -30,6 +31,7 @@ import com.expediagroup.sdk.core.configuration.provider.RuntimeConfigurationProv
  * @property maskedLoggingHeaders The headers to be masked in logging.
  * @property maskedLoggingBodyFields The body fields to be masked in logging.
  * @property authEndpoint The API endpoint to use for authentication.
+ * @property okHttpClient The okhttp client to be used by the sdk.
  */
 data class ExpediaGroupClientConfiguration(
     override val key: String? = null,
@@ -40,6 +42,7 @@ data class ExpediaGroupClientConfiguration(
     override val socketTimeout: Long? = null,
     override val maskedLoggingHeaders: Set<String>? = null,
     override val maskedLoggingBodyFields: Set<String>? = null,
+    override val okHttpClient: OkHttpClient? = null,
     val authEndpoint: String? = null
 ) : ClientConfiguration {
     /** Build a [RuntimeConfigurationProvider] from an [ExpediaGroupClientConfiguration]. */

--- a/core/src/main/kotlin/com/expediagroup/sdk/core/configuration/RapidClientConfiguration.kt
+++ b/core/src/main/kotlin/com/expediagroup/sdk/core/configuration/RapidClientConfiguration.kt
@@ -16,6 +16,7 @@
 package com.expediagroup.sdk.core.configuration
 
 import com.expediagroup.sdk.core.client.BaseRapidClient
+import okhttp3.OkHttpClient
 
 /**
  * Configuration for the [BaseRapidClient].
@@ -37,5 +38,6 @@ data class RapidClientConfiguration(
     override val connectionTimeout: Long? = null,
     override val socketTimeout: Long? = null,
     override val maskedLoggingHeaders: Set<String>? = null,
-    override val maskedLoggingBodyFields: Set<String>? = null
+    override val maskedLoggingBodyFields: Set<String>? = null,
+    val okHttpClient: OkHttpClient? = null
 ) : ClientConfiguration

--- a/core/src/main/kotlin/com/expediagroup/sdk/core/configuration/RapidClientConfiguration.kt
+++ b/core/src/main/kotlin/com/expediagroup/sdk/core/configuration/RapidClientConfiguration.kt
@@ -39,5 +39,5 @@ data class RapidClientConfiguration(
     override val socketTimeout: Long? = null,
     override val maskedLoggingHeaders: Set<String>? = null,
     override val maskedLoggingBodyFields: Set<String>? = null,
-    val okHttpClient: OkHttpClient? = null
+    override val okHttpClient: OkHttpClient? = null
 ) : ClientConfiguration

--- a/core/src/main/kotlin/com/expediagroup/sdk/core/configuration/XapClientConfiguration.kt
+++ b/core/src/main/kotlin/com/expediagroup/sdk/core/configuration/XapClientConfiguration.kt
@@ -39,5 +39,5 @@ data class XapClientConfiguration(
     override val socketTimeout: Long? = null,
     override val maskedLoggingHeaders: Set<String>? = null,
     override val maskedLoggingBodyFields: Set<String>? = null,
-    val okHttpClient: OkHttpClient? = null
+    override val okHttpClient: OkHttpClient? = null
 ) : ClientConfiguration

--- a/core/src/main/kotlin/com/expediagroup/sdk/core/configuration/XapClientConfiguration.kt
+++ b/core/src/main/kotlin/com/expediagroup/sdk/core/configuration/XapClientConfiguration.kt
@@ -16,6 +16,7 @@
 package com.expediagroup.sdk.core.configuration
 
 import com.expediagroup.sdk.core.client.BaseXapClient
+import okhttp3.OkHttpClient
 
 /**
  * Configuration for the [BaseXapClient].
@@ -37,5 +38,6 @@ data class XapClientConfiguration(
     override val connectionTimeout: Long? = null,
     override val socketTimeout: Long? = null,
     override val maskedLoggingHeaders: Set<String>? = null,
-    override val maskedLoggingBodyFields: Set<String>? = null
+    override val maskedLoggingBodyFields: Set<String>? = null,
+    val okHttpClient: OkHttpClient? = null
 ) : ClientConfiguration

--- a/core/src/main/kotlin/com/expediagroup/sdk/core/configuration/collector/ConfigurationCollector.kt
+++ b/core/src/main/kotlin/com/expediagroup/sdk/core/configuration/collector/ConfigurationCollector.kt
@@ -28,6 +28,7 @@ import com.expediagroup.sdk.core.constant.ConfigurationName.SECRET
 import com.expediagroup.sdk.core.constant.ConfigurationName.SOCKET_TIMEOUT_MILLIS
 import com.expediagroup.sdk.core.constant.provider.LoggingMessageProvider
 import com.expediagroup.sdk.core.plugin.logging.ExpediaGroupLoggerFactory
+import okhttp3.OkHttpClient
 
 /**
  * Configuration collector that collects configuration from all available providers.
@@ -66,6 +67,7 @@ internal class ConfigurationCollector private constructor(providers: Configurati
     override val socketTimeout: Long? = providers.firstWith { it.socketTimeout }.also { it?.log(SOCKET_TIMEOUT_MILLIS) }?.retrieve()
     override val maskedLoggingHeaders: Set<String>? = providers.firstWith { it.maskedLoggingHeaders }.also { it?.log(MASKED_LOGGING_HEADERS) }?.retrieve()
     override val maskedLoggingBodyFields: Set<String>? = providers.firstWith { it.maskedLoggingBodyFields }.also { it?.log(MASKED_LOGGING_BODY_FIELDS) }?.retrieve()
+    override val okHttpClient: OkHttpClient? = providers.firstWith { it.okHttpClient }?.retrieve()
 
     private fun <T> ProvidedConfiguration<T>.log(configurationName: String) {
         log.info(LoggingMessageProvider.getChosenProviderMessage(configurationName, providerName))

--- a/core/src/main/kotlin/com/expediagroup/sdk/core/configuration/provider/ConfigurationProvider.kt
+++ b/core/src/main/kotlin/com/expediagroup/sdk/core/configuration/provider/ConfigurationProvider.kt
@@ -16,6 +16,7 @@
 package com.expediagroup.sdk.core.configuration.provider
 
 import com.expediagroup.sdk.core.constant.Constant
+import okhttp3.OkHttpClient
 
 /**
  * A configuration provider that can be used to provide configuration values.
@@ -55,4 +56,8 @@ interface ConfigurationProvider {
     /** The body fields to be masked in logging.*/
     val maskedLoggingBodyFields: Set<String>?
         get() = setOf()
+
+    /** The okhttp client to be used by the sdk.*/
+    val okHttpClient: OkHttpClient?
+        get() = null
 }

--- a/core/src/main/kotlin/com/expediagroup/sdk/core/configuration/provider/RuntimeConfigurationProvider.kt
+++ b/core/src/main/kotlin/com/expediagroup/sdk/core/configuration/provider/RuntimeConfigurationProvider.kt
@@ -16,6 +16,7 @@
 package com.expediagroup.sdk.core.configuration.provider
 
 import com.expediagroup.sdk.core.constant.ConfigurationName.RUNTIME_CONFIGURATION_PROVIDER
+import okhttp3.OkHttpClient
 
 /**
  * A runtime-built configuration provider.
@@ -41,5 +42,6 @@ data class RuntimeConfigurationProvider(
     override val connectionTimeout: Long? = null,
     override val socketTimeout: Long? = null,
     override val maskedLoggingHeaders: Set<String>? = null,
-    override val maskedLoggingBodyFields: Set<String>? = null
+    override val maskedLoggingBodyFields: Set<String>? = null,
+    override val okHttpClient: OkHttpClient? = null
 ) : ConfigurationProvider

--- a/core/src/main/kotlin/com/expediagroup/sdk/core/constant/ConfigurationName.kt
+++ b/core/src/main/kotlin/com/expediagroup/sdk/core/constant/ConfigurationName.kt
@@ -37,4 +37,6 @@ internal object ConfigurationName {
     const val RUNTIME_CONFIGURATION_PROVIDER = "runtime configuration"
 
     const val CONFIGURATION_COLLECTOR = "configuration collector"
+
+    const val OKHTTP_CLIENT = "okhttp client"
 }

--- a/core/src/test/kotlin/com/expediagroup/sdk/core/configuration/ExpediaGroupClientConfigurationTest.kt
+++ b/core/src/test/kotlin/com/expediagroup/sdk/core/configuration/ExpediaGroupClientConfigurationTest.kt
@@ -32,6 +32,7 @@ class ExpediaGroupClientConfigurationTest {
             assertNull(it.socketTimeout)
             assertNull(it.maskedLoggingHeaders)
             assertNull(it.maskedLoggingBodyFields)
+            assertNull(it.okHttpClient)
         }
     }
 
@@ -72,6 +73,7 @@ class ExpediaGroupClientConfigurationTest {
             assertNull(it.socketTimeout)
             assertNull(it.maskedLoggingHeaders)
             assertNull(it.maskedLoggingBodyFields)
+            assertNull(it.okHttpClient)
         }
     }
 

--- a/generator/openapi/src/main/resources/templates/expediagroup-sdk/client.mustache
+++ b/generator/openapi/src/main/resources/templates/expediagroup-sdk/client.mustache
@@ -22,7 +22,7 @@ import kotlinx.coroutines.runBlocking
 class {{clientClassname}}Client private constructor(clientConfiguration: ExpediaGroupClientConfiguration) : ExpediaGroupClient("{{namespace}}", clientConfiguration) {
     class Builder : ExpediaGroupClient.Builder<Builder>() {
         override fun build() = {{clientClassname}}Client(
-            ExpediaGroupClientConfiguration(key, secret, endpoint, requestTimeout, connectionTimeout, socketTimeout, maskedLoggingHeaders, maskedLoggingBodyFields, authEndpoint)
+            ExpediaGroupClientConfiguration(key, secret, endpoint, requestTimeout, connectionTimeout, socketTimeout, maskedLoggingHeaders, maskedLoggingBodyFields, null, authEndpoint)
         )
     }
 


### PR DESCRIPTION
# Situation
Some users of the RAPID SDK are interested in getting more control over the underlying httpClient used by the SDK, such as tuning the dispatcher concurrency configs, or injecting interceptors/eventlisteners for monitoring purposes

# Task
Enable users to inject their own okhttp client when configuring the SDK client.

# Action
- Client builder is modified into two builders, one with the shared configs, and another one extended with the timeouts configs.
- All existing base clients extend the Client.BuilderExtension to maintain current behaviour
- A new builder method that takes an okHttpClient as a configuration is added. 
- okHttpClient is added to the RAPID client configuration
- Users can still configure timeouts on the default existing okhttp client

# Testing
Manual testing by running the rapid examples covering test-cases:
- Configuring timeouts on RAPID client
- Configuring a custom okHttpClient, user is unable to configure timeouts outside the httpclient.
- Configuring a client with the existing builder, users are able to set timeouts.

# Results
Users are able to build and inject a custom okhttp client to be used by the SDK for executing requests.