### PR TITLE
chore: update renovate to exclude release folder

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,6 +3,9 @@
   "extends": [
     "local>ExpediaGroup/renovate-config"
   ],
+  "ignorePaths": [
+    "release/**"
+  ],
   "maven": {
     "fileMatch": [
       "^.*\\/pom\\.xml$",


### PR DESCRIPTION
# Situation
Renovate bot updates dependencies in the `release` folder, creating unnecessary PRs.

# Task
Exclude the `release` folder from Renovate's automated updates.

# Action
Added `ignorePaths` with `"release/**"` pattern in `renovate.json`.

# Testing
Validated configuration using `renovate-config-validator`.

# Results
Renovate will skip dependency updates in the `release` folder.

# Notes
Renovate docs: https://docs.renovatebot.com/configuration-options/#ignorepaths