### PR TITLE
fix: inconsistent custom okhttp configuration

### DIFF
--- a/core/src/main/kotlin/com/expediagroup/sdk/core/client/BaseRapidClient.kt
+++ b/core/src/main/kotlin/com/expediagroup/sdk/core/client/BaseRapidClient.kt
@@ -43,7 +43,10 @@ abstract class BaseRapidClient(
 
     private val engine: HttpClientEngine = _configurationProvider.okHttpClient?.let {
         OkHttp.create {
-            preconfigured = it
+             config {
+                 preconfigured = it
+                 dispatcher(it.dispatcher)
+             }
         }
     } ?: httpClientEngine
 

--- a/core/src/main/kotlin/com/expediagroup/sdk/core/client/BaseXapClient.kt
+++ b/core/src/main/kotlin/com/expediagroup/sdk/core/client/BaseXapClient.kt
@@ -43,7 +43,10 @@ abstract class BaseXapClient(
 
     private val engine: HttpClientEngine = _configurationProvider.okHttpClient?.let {
         OkHttp.create {
-            preconfigured = it
+            config {
+                preconfigured = it
+                dispatcher(it.dispatcher)
+            }
         }
     } ?: httpClientEngine
 


### PR DESCRIPTION
# Situation
In [pull-request#857](https://github.com/ExpediaGroup/expediagroup-java-sdk/pull/857), we proposed a new feature that enables users to inject their own OkHttp client when configuring the SDK client.

A bug was reported to us that custom `Dispatcher` configurations on `OkHttpClient` instances are being overridden by OkHttp's default configurations. Look the example below:

```kotlin
val okhttp = OkHttpClient.Builder()
    .dispatcher(
        Dispatcher().apply {
            maxRequests = 5000
            maxRequestsPerHost = 1000
        }
    )
    .build()

val client = RapidClient.builderWithHttpClient()
    .okHttpClient(okHttpClient = okhttp)
    .key("key")
    .secret("secret")
    .build()
```

In the previous example, we expect `maxRequests` and `maxRequestsPerHost` values to be configured properly to their given values. Unfortunately, that's not the case, and configurations are overridden to OkHttp's default values. 
![image](https://github.com/user-attachments/assets/fb240eb2-2771-45ce-a354-639fa8363245)

We pass custom `OkHttpClient` instance to `Ktor` through the [`HttpClientEngineFactory`](https://github.com/ktorio/ktor/blob/2229b2bb9e439199c5bfedac1dcfae6179a11579/ktor-client/ktor-client-okhttp/jvm/src/io/ktor/client/engine/okhttp/OkHttp.kt) utility, which enables us to create and configure instances of the [`OkHttpEngine`](https://ktor.io/docs/client-engines.html#jvm). 

```kotlin
abstract class BaseRapidClient(
    namespace: String,
    clientConfiguration: RapidClientConfiguration,
    httpClientEngine: HttpClientEngine = DEFAULT_HTTP_CLIENT_ENGINE,
) : Client(namespace) {
    // code... code... code... 
    private val engine: HttpClientEngine =
        _configurationProvider.okHttpClient?.let {
            OkHttp.create {
                preconfigured = it
            }
        } ?: httpClientEngine
    // code... code... code... 
}
```

When we pass an `OkHttpClient` instance to the `Ktor` client, `Ktor` attempts to clone our `OkHttpClient` instance, then executing our configuration code-block. The issue is that `Ktor` creates a new dispatcher instance and setting it on the new instance after cloning our client. Looking the `Ktor` code-base, we can observe that behavior in the following code:

```kotlin
public class OkHttpEngine(override val config: OkHttpConfig) : HttpClientEngineBase("ktor-okhttp") {
    // code... code... code... 
    private val clientCache = createLRUCache(::createOkHttpClient, {}, config.clientCacheSize)

    // code... code... code... 
    private fun createOkHttpClient(timeoutExtension: HttpTimeout.HttpTimeoutCapabilityConfiguration?): OkHttpClient {
        val builder = (config.preconfigured ?: okHttpClientPrototype).newBuilder()

        builder.dispatcher(Dispatcher())
        builder.apply(config.config)
        config.proxy?.let { builder.proxy(it) }
        timeoutExtension?.let {
            builder.setupTimeoutAttributes(it)
        }

        return builder.build()
    }
}
```
Breaking down the code, we can observe the following facts:
1. Our `OkHttpClient` instance is cloned and transformed into an instance of `OkHttpBuilder`.
```kotlin
val builder = (config.preconfigured ?: okHttpClientPrototype).newBuilder()
```
2. A new `Dispatcher` instance is created and set on the new builder.
```kotlin
builder.dispatcher(Dispatcher())
```
3. Our custom-configuration block is executed on the OkHttpBuilder instance.
```kotlin
builder.apply(config.config)
```

As a result, our custom `Dispatcher` instance is overridden by a new instance holding the default values set in the `Dispatcher` class.

# Task
In order to resolve the issue and persist custom `Dispatcher` instances, we need to make sure the the `Dispatcher` instances is set again properly in the `ustom-configuration block`. We do not need to care about other values and configurations since they are cloned properly and not overridden later on.

# Action
For each client, we made sure `Dispatcher` instances are set properly on the custom-configuration block level.
```kotlin
OkHttp.create {
     config {
         preconfigured = it
         dispatcher(it.dispatcher)
     }
}
```

# Testing
Verified manually. It would be hard to unit-test setting custom `OkHttpClient` instances because the instance is set to be inaccessible (private-visibility).

# Results
Custom `Dispatcher` instances are now preserved and respected. Given the following configuration as a sample:
```kotlin
val okhttp = OkHttpClient.Builder()
    .dispatcher(
        Dispatcher().apply {
            maxRequests = 5000
            maxRequestsPerHost = 1000
        }
    )
    .build()

val client = RapidClient.builderWithHttpClient()
    .okHttpClient(okHttpClient = okhttp)
    .key("key")
    .secret("secret")
    .build()
```
We can observe that our configurations are respected and preserved for each request.
![image](https://github.com/user-attachments/assets/53276ef9-7ed2-4e07-be5a-0558c2bd7bd0)


# Notes
**NaN**
