### PR TITLE
feat: enable using enums in headers and separate operation params imp…

### DIFF
--- a/generator/openapi/src/main/resources/templates/expediagroup-sdk/imports/operation_params.mustache
+++ b/generator/openapi/src/main/resources/templates/expediagroup-sdk/imports/operation_params.mustache
@@ -1,0 +1,25 @@
+import com.expediagroup.sdk.core.model.exception.client.PropertyConstraintViolationException
+import com.expediagroup.sdk.core.model.OperationParams
+
+import com.fasterxml.jackson.annotation.JsonProperty
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize
+import io.ktor.http.Headers
+import io.ktor.http.Parameters
+
+import javax.validation.constraints.Max
+import javax.validation.constraints.Min
+import javax.validation.constraints.NotNull
+import javax.validation.constraints.Pattern
+import javax.validation.constraints.Size
+import javax.validation.Valid
+import javax.validation.Validation
+
+{{#nonBodyParams}}
+    {{#params}}
+        {{#isEnumRef}}{{^isEnum}}
+            import {{packageName}}.models.{{#lambda.titlecase}}{{paramName}}{{/lambda.titlecase}}
+        {{/isEnum}}{{/isEnumRef}}
+    {{/params}}
+{{/nonBodyParams}}
+
+import org.hibernate.validator.messageinterpolation.ParameterMessageInterpolator

--- a/generator/openapi/src/main/resources/templates/expediagroup-sdk/operation_params.mustache
+++ b/generator/openapi/src/main/resources/templates/expediagroup-sdk/operation_params.mustache
@@ -3,23 +3,7 @@
         {{#hasNonBodyParams}}
             package com.expediagroup.sdk.{{namespace}}.operations
 
-            import com.expediagroup.sdk.core.model.exception.client.PropertyConstraintViolationException
-            import com.expediagroup.sdk.core.model.OperationParams
-
-            import com.fasterxml.jackson.annotation.JsonProperty
-            import com.fasterxml.jackson.databind.annotation.JsonDeserialize
-            import io.ktor.http.Headers
-            import io.ktor.http.Parameters
-
-            import javax.validation.constraints.Max
-            import javax.validation.constraints.Min
-            import javax.validation.constraints.NotNull
-            import javax.validation.constraints.Pattern
-            import javax.validation.constraints.Size
-            import javax.validation.Valid
-            import javax.validation.Validation
-
-            import org.hibernate.validator.messageinterpolation.ParameterMessageInterpolator
+            {{>imports/operation_params}}
 
             /**
             {{#nonBodyParams}}
@@ -120,10 +104,16 @@
                 )
 
                 override fun getHeaders(): Headers {
-                    return Headers.build {
-                        {{#headerParams}}
-                            {{paramName}}?.let {
-                                append("{{baseName}}", it{{#isEnum}}.value{{/isEnum}})
+                return Headers.build {
+                    {{#headerParams}}
+                        {{paramName}}?.let {
+                            append(
+                                "{{baseName}}",
+                                it
+                                    {{#isEnum}}.value{{/isEnum}}
+                                    {{^isEnum}}{{#isEnumRef}}.value{{/isEnumRef}}{{/isEnum}}
+                                    {{#isUuid}}.toString(){{/isUuid}}
+                                )
                             }
                         {{/headerParams}}
                         {{#responses}}


### PR DESCRIPTION
…orts into a partial template

# Situation
New APIs use enums used in headers and uuid strings.

# Task
Enable using enums and uuid in headers

# Action
Handle enums and uuid in operation params templates, extract operation params imports into its own template to reduce friction with product sdks customizations.

# Testing
Generated an SDK with enums and uuid in headers.

# Results
SDK generation can identify and handle uuid and enums when passed in headers.

# Notes
N/A
