### PR TITLE
feat: add OpenAPI generator wrapper plugin

### DIFF
--- a/expediagroup-sdk-openapi-plugin/build.gradle
+++ b/expediagroup-sdk-openapi-plugin/build.gradle
@@ -1,0 +1,58 @@
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+
+plugins {
+    id 'java-gradle-plugin'
+    id 'maven-publish'
+}
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    implementation 'org.openapitools:openapi-generator-gradle-plugin:7.11.0'
+}
+
+kotlin {
+    jvmToolchain(11)
+}
+
+java {
+    withSourcesJar()
+    sourceCompatibility = JavaVersion.VERSION_11
+    targetCompatibility = JavaVersion.VERSION_11
+}
+
+
+tasks.withType(KotlinCompile).configureEach {
+    kotlinOptions {
+        jvmTarget = '11'
+    }
+}
+
+
+gradlePlugin {
+    plugins {
+        create("egSdkOpenApiGenerator") {
+            id = "com.expediagroup.sdk.openapigenerator"
+            implementationClass = "com.expediagroup.sdk.openapigenerator.EgSdkOpenApiGeneratorPlugin"
+            displayName = "EG SDK OpenApi Gradle Plugin Wrapper"
+            description = "applies the standard OpenAPI Generator plugin (\"org.openapi.generator\") and configures it with Expedia Group SDK defaults."
+        }
+    }
+}
+
+publishing {
+    publications {
+        mavenLocal(MavenPublication) {
+            artifactId = 'expediagroup-sdk-openapi-plugin'
+            version = '1.0.0-SNAPSHOT'
+            groupId = project.property('groupId')
+
+            from components.java
+        }
+    }
+    repositories {
+        mavenLocal()
+    }
+}

--- a/expediagroup-sdk-openapi-plugin/build.gradle
+++ b/expediagroup-sdk-openapi-plugin/build.gradle
@@ -10,6 +10,7 @@ repositories {
 }
 
 dependencies {
+    implementation 'org.openapitools:openapi-generator:7.11.0'
     implementation 'org.openapitools:openapi-generator-gradle-plugin:7.11.0'
 }
 

--- a/expediagroup-sdk-openapi-plugin/src/main/kotlin/com/expediagroup/sdk/openapigenerator/EgSdkOpenApiGeneratorPlugin.kt
+++ b/expediagroup-sdk-openapi-plugin/src/main/kotlin/com/expediagroup/sdk/openapigenerator/EgSdkOpenApiGeneratorPlugin.kt
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2025 Expedia, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.expediagroup.sdk.openapigenerator
+
+import com.expediagroup.sdk.openapigenerator.util.OpenApiGeneratorConfigurator
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.openapitools.generator.gradle.plugin.extensions.OpenApiGeneratorGenerateExtension
+
+/**
+ * A Gradle plugin that applies the standard OpenAPI Generator plugin ("org.openapi.generator")
+ * and configures it with Expedia Group SDK defaults.
+ *
+ * This plugin will:
+ * 1. Apply the official "org.openapi.generator" plugin.
+ * 2. Retrieve the [OpenApiGeneratorGenerateExtension].
+ * 3. Invoke [OpenApiGeneratorConfigurator.configure] to set custom default settings.
+ */
+class EgSdkOpenApiGeneratorPlugin : Plugin<Project> {
+    /**
+     * Invoked by Gradle when this plugin is applied to a project.
+     * Applies the base OpenAPI Generator plugin and configures
+     * the extension using [OpenApiGeneratorConfigurator].
+     *
+     * @param project the Gradle [Project] on which the plugin is being applied
+     */
+    override fun apply(project: Project) {
+        project.pluginManager.apply("org.openapi.generator")
+
+        project.extensions.configure(OpenApiGeneratorGenerateExtension::class.java) { ext ->
+            OpenApiGeneratorConfigurator.configure(project, ext)
+        }
+    }
+}

--- a/expediagroup-sdk-openapi-plugin/src/main/kotlin/com/expediagroup/sdk/openapigenerator/mustache/Discriminator.kt
+++ b/expediagroup-sdk-openapi-plugin/src/main/kotlin/com/expediagroup/sdk/openapigenerator/mustache/Discriminator.kt
@@ -1,0 +1,34 @@
+package com.expediagroup.sdk.openapigenerator.mustache
+
+import org.openapitools.codegen.CodegenModel
+
+internal fun getParentDiscriminator(model: CodegenModel): MutableList<Discriminator> {
+    if (model.parentModel === null) return mutableListOf()
+    val discriminators: MutableList<Discriminator> = getParentDiscriminator(model.parentModel)
+    model.parentModel.vars?.find { it.isDiscriminator }?.let { variable ->
+        model.parentModel?.discriminator?.let {
+            discriminators.add(
+                Discriminator(
+                    it.propertyBaseName,
+                    it.propertyName,
+                    variable.datatypeWithEnum,
+                    it.mappedModels.find { mappedModel -> mappedModel.modelName.equals(model.classname) }!!.mappingName.uppercase(),
+                    model.parentModel.name,
+                    variable.isEnum,
+                    variable.isString
+                )
+            )
+        }
+    }
+    return discriminators
+}
+
+internal data class Discriminator(
+    val originalName: String,
+    val name: String,
+    val type: String,
+    val value: String,
+    val parentName: String,
+    val isEnum: Boolean,
+    val isString: Boolean
+)

--- a/expediagroup-sdk-openapi-plugin/src/main/kotlin/com/expediagroup/sdk/openapigenerator/mustache/Lambdas.kt
+++ b/expediagroup-sdk-openapi-plugin/src/main/kotlin/com/expediagroup/sdk/openapigenerator/mustache/Lambdas.kt
@@ -1,0 +1,179 @@
+package com.expediagroup.sdk.openapigenerator.mustache
+
+import com.samskivert.mustache.Mustache
+import com.samskivert.mustache.Template
+import org.openapitools.codegen.CodegenModel
+import org.openapitools.codegen.CodegenOperation
+import org.openapitools.codegen.CodegenProperty
+import org.openapitools.codegen.CodegenResponse
+import org.openapitools.codegen.model.ApiInfoMap
+import java.io.Serializable
+import java.io.Writer
+
+class IsPaginatableLambda : Mustache.Lambda, Serializable {
+    override fun execute(
+        fragment: Template.Fragment,
+        writer: Writer
+    ) {
+        val operation = fragment.context() as CodegenOperation
+        if (operation.returnType == null) return
+
+        val paginationHeaders = listOf("Pagination-Total-Results", "Link")
+        val availableHeaders = operation.responses.find { it.code == "200" }?.headers?.filter { it.baseName in paginationHeaders }
+        if (availableHeaders?.size == paginationHeaders.size) {
+            val fallbackBody =
+                when {
+                    operation.returnType.startsWith("kotlin.collections.List") -> "emptyList()"
+                    operation.returnType.startsWith("kotlin.collections.Map") -> "emptyMap()"
+                    operation.returnType.startsWith("kotlin.collections.Set") -> "emptySet()"
+                    else -> ""
+                }
+
+            val context = mapOf("fallbackBody" to fallbackBody)
+            fragment.execute(context, writer)
+        }
+    }
+}
+
+class RemoveLeadingSlashesLambda : Mustache.Lambda, Serializable {
+    override fun execute(
+        fragment: Template.Fragment,
+        writer: Writer
+    ) {
+        writer.write(fragment.execute().replace("^/+".toRegex(), "/"))
+    }
+}
+
+class AssignDiscriminatorsLambda : Mustache.Lambda, Serializable {
+    override fun execute(
+        fragment: Template.Fragment,
+        writer: Writer
+    ) {
+        val model = fragment.context() as CodegenModel
+        getParentDiscriminator(model).forEach {
+            val type: String = (if (it.isEnum) "${it.parentName}." else "") + it.type
+            val value: String = if (it.isString && !it.isEnum) "\"${it.value}\"" else "$type.${it.value}"
+            writer.write("@JsonProperty(\"${it.originalName}\")\n")
+            writer.write("override val ${it.name} : $type = $value\n")
+        }
+    }
+}
+
+class EliminateDiscriminatorsLambda : Mustache.Lambda, Serializable {
+    override fun execute(
+        fragment: Template.Fragment,
+        writer: Writer
+    ) {
+        val discriminators: List<String> = getParentDiscriminator(fragment.context(1) as CodegenModel).map { it.originalName }
+        val property = fragment.context() as CodegenProperty
+        if (!discriminators.contains(property.baseName)) {
+            writer.write(fragment.execute())
+        }
+    }
+}
+
+class DefineApiExceptionsLambda : Mustache.Lambda, Serializable {
+    override fun execute(
+        fragment: Template.Fragment,
+        writer: Writer
+    ) {
+        val dataTypes: MutableSet<String> = mutableSetOf()
+        val apisMap: ApiInfoMap = fragment.context() as ApiInfoMap
+        apisMap.apis.forEach { operationsMap ->
+            operationsMap.operations.operation.forEach { operation ->
+                operation.responses.forEach { response ->
+                    response.takeIf { !it.is2xx && !dataTypes.contains(it.dataType) }?.dataType?.also {
+                        dataTypes.add(it)
+                    }
+                }
+            }
+        }
+
+        dataTypes.forEach { dataType ->
+            val context = mapOf("dataType" to dataType)
+            fragment.execute(context, writer)
+        }
+    }
+}
+
+class ExceptionDataTypesLambda : Mustache.Lambda, Serializable {
+    override fun execute(
+        fragment: Template.Fragment,
+        writer: Writer
+    ) {
+        val operation: CodegenOperation = fragment.context() as CodegenOperation
+        val dataTypes: Set<String> = operation.responses.filter { !it.is2xx }.map { it.dataType }.toSet()
+        val context = mapOf("dataTypes" to dataTypes)
+        fragment.execute(context, writer)
+    }
+}
+
+class HasNonBodyParamsLambda : Mustache.Lambda, Serializable {
+    override fun execute(
+        fragment: Template.Fragment,
+        writer: Writer
+    ) {
+        val operation = fragment.context() as CodegenOperation
+        if (operation.hasPathParams || operation.hasHeaderParams || operation.hasQueryParams) {
+            fragment.execute(writer)
+        }
+    }
+}
+
+class NonBodyParamsLambda : Mustache.Lambda, Serializable {
+    override fun execute(
+        fragment: Template.Fragment,
+        writer: Writer
+    ) {
+        val operation = fragment.context() as CodegenOperation
+        val params = operation.pathParams + operation.headerParams + operation.queryParams
+        val context = mapOf("params" to params)
+        fragment.execute(context, writer)
+    }
+}
+
+class RemoveDoubleQuotesLambda : Mustache.Lambda, Serializable {
+    override fun execute(
+        fragment: Template.Fragment,
+        writer: Writer
+    ) {
+        val data: String = fragment.context() as String
+        writer.write("\"${data.replace(Regex("^\"+|\"$"), "")}\"")
+    }
+}
+
+class HttpAcceptHeaderLambda : Mustache.Lambda, Serializable {
+    override fun execute(
+        fragment: Template.Fragment,
+        writer: Writer
+    ) {
+        val response: CodegenResponse = fragment.context() as CodegenResponse
+        if (response.code == "200") {
+            val mediaTypes: MutableSet<String> = response.content.keys
+            val context = mapOf("mediaTypes" to mediaTypes.joinToString(","))
+            fragment.execute(context, writer)
+        }
+    }
+}
+
+class CustomReturnTypeLambda : Mustache.Lambda, Serializable {
+    override fun execute(
+        fragment: Template.Fragment,
+        writer: Writer
+    ) {
+        val response: CodegenOperation = fragment.context() as CodegenOperation
+        val context =
+            mapOf(
+                "returnType" to
+                    when (response.returnType) {
+                        "java.io.File" -> "java.io.InputStream"
+                        else -> response.returnType
+                    }
+            )
+
+        if (context["returnType"] == null) {
+            return
+        }
+        fragment.execute(context, writer)
+    }
+}

--- a/expediagroup-sdk-openapi-plugin/src/main/kotlin/com/expediagroup/sdk/openapigenerator/util/MustacheTemplatesHandler.kt
+++ b/expediagroup-sdk-openapi-plugin/src/main/kotlin/com/expediagroup/sdk/openapigenerator/util/MustacheTemplatesHandler.kt
@@ -1,0 +1,156 @@
+/*
+ * Copyright (C) 2025 Expedia, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.expediagroup.sdk.openapigenerator.util
+
+import org.gradle.api.Project
+import org.gradle.api.file.DuplicatesStrategy
+import org.gradle.api.logging.Logging
+import org.openapitools.generator.gradle.plugin.extensions.OpenApiGeneratorGenerateExtension
+import java.io.File
+import java.net.JarURLConnection
+import java.net.URL
+import kotlin.sequences.asSequence
+
+/**
+ * Responsible for assembling final Mustache templates,
+ * combining default templates and any user-provided templates.
+ */
+object MustacheTemplatesHandler {
+    private val logger = Logging.getLogger(this.javaClass)
+
+    /** Directory name where default templates reside within resources. */
+    const val DEFAULT_TEMPLATES_DIR_NAME = "templates"
+
+    /** Directory name used inside the build folder for merged final templates. */
+    const val FINAL_TEMPLATES_DIR_NAME = "final_templates"
+
+    /**
+     * Creates or locates the final templates directory, populates it with default templates,
+     * and merges any externally provided templates.
+     *
+     * @param project The Gradle [Project] instance.
+     * @return The absolute path to the final templates' directory.
+     */
+    fun resolveFinalTemplates(project: Project): String {
+        val finalTemplatesDirectory = initializeFinalTemplatesDirectory(project)
+        extractDefaultTemplates(finalTemplatesDirectory)
+        setupExternalTemplatesMerge(project, finalTemplatesDirectory)
+        return finalTemplatesDirectory.absolutePath
+    }
+
+    /**
+     * Ensures the final templates directory exists in the build folder.
+     * If it doesn't exist, it is created.
+     *
+     * @param project The Gradle [Project] instance.
+     * @return A [File] pointing to the final templates' directory.
+     */
+    private fun initializeFinalTemplatesDirectory(project: Project): File {
+        val finalDir = project.layout.buildDirectory.dir(FINAL_TEMPLATES_DIR_NAME).get().asFile
+        if (!finalDir.exists()) {
+            finalDir.mkdirs()
+            logger.info("Created final templates directory: ${finalDir.absolutePath}")
+        }
+        return finalDir
+    }
+
+    /**
+     * Extracts built-in default templates from this JAR (under the given resource path)
+     * and copies them into the provided target directory.
+     *
+     * @param targetDir Where to copy the default templates.
+     */
+    private fun extractDefaultTemplates(targetDir: File) {
+        val resourceUrl = this::class.java.classLoader.getResource(DEFAULT_TEMPLATES_DIR_NAME)
+        if (resourceUrl == null) {
+            logger.warn("Default templates directory not found: $DEFAULT_TEMPLATES_DIR_NAME")
+            return
+        }
+
+        when (resourceUrl.protocol) {
+            "jar" -> extractResourcesFromJar(resourceUrl, targetDir)
+            else -> logger.error("Unsupported resource protocol: ${resourceUrl.protocol}")
+        }
+    }
+
+    /**
+     * Reads all entries under [DEFAULT_TEMPLATES_DIR_NAME] from the JAR file
+     * and copies them into [targetDir].
+     *
+     * @param resourceUrl The URL pointing to the default templates in the JAR.
+     * @param targetDir The final destination for extracted files.
+     */
+    private fun extractResourcesFromJar(
+        resourceUrl: URL,
+        targetDir: File
+    ) {
+        try {
+            val connection = resourceUrl.openConnection() as JarURLConnection
+            connection.jarFile.use { jarFile ->
+                jarFile.entries().asSequence()
+                    .filter { it.name.startsWith("$DEFAULT_TEMPLATES_DIR_NAME/") && !it.isDirectory }
+                    .forEach { entry ->
+                        val relativePath = entry.name.removePrefix("$DEFAULT_TEMPLATES_DIR_NAME/")
+                        val outputFile = File(targetDir, relativePath)
+
+                        outputFile.parentFile.mkdirs()
+                        jarFile.getInputStream(entry).use { input ->
+                            outputFile.outputStream().use { output -> input.copyTo(output) }
+                        }
+
+                        logger.debug("Copied default template: $relativePath")
+                    }
+            }
+        } catch (e: Exception) {
+            logger.error("Failed to copy templates from JAR", e)
+        }
+    }
+
+    /**
+     * After project evaluation, merges any user-defined templates from the OpenApi Generator extension
+     * into the final templates' directory.
+     *
+     * @param project The Gradle [Project] instance.
+     * @param finalTemplatesDirectory The destination directory for merged templates.
+     */
+    private fun setupExternalTemplatesMerge(
+        project: Project,
+        finalTemplatesDirectory: File
+    ) {
+        project.afterEvaluate {
+            val openApiExt =
+                it.extensions.findByType(OpenApiGeneratorGenerateExtension::class.java)
+                    ?: return@afterEvaluate
+
+            val externalTemplatePath = openApiExt.templateDir.orNull ?: return@afterEvaluate
+            val externalTemplateDir = project.file(externalTemplatePath).takeIf { dir -> dir.exists() }
+
+            if (externalTemplateDir == null) {
+                logger.warn("External templates directory not found: $externalTemplatePath")
+                return@afterEvaluate
+            }
+
+            project.copy { copySpec ->
+                copySpec.from(externalTemplateDir)
+                copySpec.into(finalTemplatesDirectory)
+                copySpec.duplicatesStrategy = DuplicatesStrategy.INCLUDE
+            }
+
+            logger.lifecycle("Merged user templates from $externalTemplatePath into ${finalTemplatesDirectory.absolutePath}")
+        }
+    }
+}

--- a/expediagroup-sdk-openapi-plugin/src/main/kotlin/com/expediagroup/sdk/openapigenerator/util/OpenApiGeneratorConfigurator.kt
+++ b/expediagroup-sdk-openapi-plugin/src/main/kotlin/com/expediagroup/sdk/openapigenerator/util/OpenApiGeneratorConfigurator.kt
@@ -1,0 +1,91 @@
+/*
+ * Copyright (C) 2025 Expedia, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.expediagroup.sdk.openapigenerator.util
+
+import org.gradle.api.Project
+import org.openapitools.generator.gradle.plugin.extensions.OpenApiGeneratorGenerateExtension
+
+/**
+ * Configures an [OpenApiGeneratorGenerateExtension] instance with default settings specific to
+ * Expedia Group's SDK requirements, while allowing user overrides.
+ *
+ * This object:
+ * 1. Resolves a final templates' directory.
+ * 2. Validates that a "namespace" project property is set.
+ * 3. Sets default Kotlin-based generation options.
+ * 4. Merges user-supplied global and additional properties with SDK defaults.
+ */
+object OpenApiGeneratorConfigurator {
+    /**
+     * Applies default configuration values to the given [ext] extension after the project is evaluated.
+     *
+     * - **Namespace requirement**: Expects a "namespace" property to be defined in `gradle.properties`.
+     * - **Templates**: Resolves a local directory containing Mustache templates and sets it on `ext.templateDir`.
+     * - **Packaging**: Derives group, package, and API model paths from the [Product].
+     * - **Properties**: Merges default global and additional properties with user-defined ones.
+     *
+     * @param project The Gradle [Project] where the plugin is applied.
+     * @param ext The [OpenApiGeneratorGenerateExtension] to configure.
+     * @throws IllegalArgumentException if the "namespace" property is missing or blank.
+     */
+    fun configure(
+        project: Project,
+        ext: OpenApiGeneratorGenerateExtension
+    ) {
+        val finalTemplatesDirectoryPath = MustacheTemplatesHandler.resolveFinalTemplates(project)
+
+        project.afterEvaluate {
+            val namespace = project.properties["namespace"]?.toString()
+
+            require(!namespace.isNullOrBlank()) {
+                "namespace must be set. Make sure to specify the SDK namespace in gradle.properties"
+            }
+
+            val product = Product(namespace)
+
+            // Set official defaults / conventions
+            ext.generatorName.set("kotlin")
+            ext.templateDir.set(finalTemplatesDirectoryPath)
+
+            ext.groupId.convention(product.groupId)
+            ext.packageName.convention(product.packageName)
+            ext.apiPackage.convention(product.apiPackage)
+            ext.modelPackage.convention(product.modelsPackage)
+
+            // Merge global properties
+            val defaultGlobalProps =
+                mapOf(
+                    "models" to "",
+                    "apis" to "",
+                    "supportingFiles" to "false",
+                    "modelDocs" to "false",
+                    "modelTests" to "false"
+                )
+            val userGlobalProps = ext.globalProperties.orNull ?: emptyMap<String, String>()
+            ext.globalProperties.set(defaultGlobalProps + userGlobalProps)
+
+            // Merge additional properties
+            val defaultAdditionalProps =
+                mapOf(
+                    "namespace" to namespace.lowercase(),
+                    "apiSuffix" to "Operation"
+                )
+            val userAdditionalProps = ext.additionalProperties.orNull ?: emptyMap<String, Any>()
+            ext.additionalProperties.set(defaultAdditionalProps + userAdditionalProps)
+        }
+    }
+}

--- a/expediagroup-sdk-openapi-plugin/src/main/kotlin/com/expediagroup/sdk/openapigenerator/util/OpenApiGeneratorConfigurator.kt
+++ b/expediagroup-sdk-openapi-plugin/src/main/kotlin/com/expediagroup/sdk/openapigenerator/util/OpenApiGeneratorConfigurator.kt
@@ -16,6 +16,17 @@
 
 package com.expediagroup.sdk.openapigenerator.util
 
+import com.expediagroup.sdk.openapigenerator.mustache.AssignDiscriminatorsLambda
+import com.expediagroup.sdk.openapigenerator.mustache.CustomReturnTypeLambda
+import com.expediagroup.sdk.openapigenerator.mustache.DefineApiExceptionsLambda
+import com.expediagroup.sdk.openapigenerator.mustache.EliminateDiscriminatorsLambda
+import com.expediagroup.sdk.openapigenerator.mustache.ExceptionDataTypesLambda
+import com.expediagroup.sdk.openapigenerator.mustache.HasNonBodyParamsLambda
+import com.expediagroup.sdk.openapigenerator.mustache.HttpAcceptHeaderLambda
+import com.expediagroup.sdk.openapigenerator.mustache.IsPaginatableLambda
+import com.expediagroup.sdk.openapigenerator.mustache.NonBodyParamsLambda
+import com.expediagroup.sdk.openapigenerator.mustache.RemoveDoubleQuotesLambda
+import com.expediagroup.sdk.openapigenerator.mustache.RemoveLeadingSlashesLambda
 import org.gradle.api.Project
 import org.openapitools.generator.gradle.plugin.extensions.OpenApiGeneratorGenerateExtension
 
@@ -84,8 +95,24 @@ object OpenApiGeneratorConfigurator {
                     "namespace" to product.namespace,
                     "apiSuffix" to "Operation"
                 )
+
+            val lambdas =
+                mapOf(
+                    "customReturnType" to CustomReturnTypeLambda(),
+                    "httpAcceptHeader" to HttpAcceptHeaderLambda(),
+                    "removeDoubleQuotes" to RemoveDoubleQuotesLambda(),
+                    "nonBodyParams" to NonBodyParamsLambda(),
+                    "hasNonBodyParams" to HasNonBodyParamsLambda(),
+                    "exceptionDataTypes" to ExceptionDataTypesLambda(),
+                    "defineApiExceptions" to DefineApiExceptionsLambda(),
+                    "eliminateDiscriminators" to EliminateDiscriminatorsLambda(),
+                    "assignDiscriminators" to AssignDiscriminatorsLambda(),
+                    "removeLeadingSlashes" to RemoveLeadingSlashesLambda(),
+                    "isPaginatable" to IsPaginatableLambda()
+                )
+
             val userAdditionalProps = ext.additionalProperties.orNull ?: emptyMap<String, Any>()
-            ext.additionalProperties.set(defaultAdditionalProps + userAdditionalProps)
+            ext.additionalProperties.set(defaultAdditionalProps + userAdditionalProps + lambdas)
         }
     }
 }

--- a/expediagroup-sdk-openapi-plugin/src/main/kotlin/com/expediagroup/sdk/openapigenerator/util/OpenApiGeneratorConfigurator.kt
+++ b/expediagroup-sdk-openapi-plugin/src/main/kotlin/com/expediagroup/sdk/openapigenerator/util/OpenApiGeneratorConfigurator.kt
@@ -81,7 +81,7 @@ object OpenApiGeneratorConfigurator {
             // Merge additional properties
             val defaultAdditionalProps =
                 mapOf(
-                    "namespace" to namespace.lowercase(),
+                    "namespace" to product.namespace,
                     "apiSuffix" to "Operation"
                 )
             val userAdditionalProps = ext.additionalProperties.orNull ?: emptyMap<String, Any>()

--- a/expediagroup-sdk-openapi-plugin/src/main/kotlin/com/expediagroup/sdk/openapigenerator/util/Product.kt
+++ b/expediagroup-sdk-openapi-plugin/src/main/kotlin/com/expediagroup/sdk/openapigenerator/util/Product.kt
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 2025 Expedia, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.expediagroup.sdk.openapigenerator.util
+
+val NON_ALPHANUMERIC_REGEX = Regex("[^a-zA-Z0-9]")
+
+class Product(namespace: String) {
+    val namespace: String = namespace.replace(NON_ALPHANUMERIC_REGEX, "").lowercase()
+
+    val apiPackage: String
+        get() = "com.expediagroup.sdk.$namespace.operations"
+
+    val modelsPackage: String
+        get() = "com.expediagroup.sdk.$namespace.models"
+
+    val packageName: String
+        get() = "com.expediagroup.sdk.$namespace"
+
+    val groupId: String
+        get() = "com.expediagroup"
+}

--- a/expediagroup-sdk-openapi-plugin/src/main/resources/config/generator-config.yaml
+++ b/expediagroup-sdk-openapi-plugin/src/main/resources/config/generator-config.yaml
@@ -1,0 +1,4 @@
+files:
+  operation_params.mustache:
+    templateType: API
+    destinationFilename: Params.kt

--- a/settings.gradle
+++ b/settings.gradle
@@ -8,4 +8,5 @@ include 'expediagroup-sdk-core'
 include 'expediagroup-sdk-transport-okhttp'
 include 'expediagroup-sdk-graphql'
 include 'expediagroup-sdk-rest'
+include 'expediagroup-sdk-openapi-plugin'
 


### PR DESCRIPTION
# Situation
<!-- Describe the background or context leading to this change. Include why this work is needed (e.g., a specific problem, user need, or opportunity). What is the current state or issue that prompted this PR? -->
Adding a new module `expediagroup-sdk-openapi-plugin` that will be used in product SDKs to generate models and operations from an OpenAPI spec, replacing the current setup that depends on calling the generator by GitHub actions.

This plugin uses the default [OpenAPI Gradle plugin](https://github.com/OpenAPITools/openapi-generator/tree/master/modules/openapi-generator-gradle-plugin) internally and applies the SDK defaults (e.g. `apiSuffix`, `groupId`, `apiPackage`, etc...) enabling product SDKs to get the default configurations out-of-the-box and still be able to override the default configurations as needed.

> [!NOTE] 
> This PR introduces the foundations and the skeleton of the plugin module. Mustache templates and other templating logic will follow up in a separate PR.

# Task
<!-- Explain the goal or objective of this change. What specifically needs to be achieved to resolve the situation? Clearly define the scope of the task at hand. -->
The goal of this PR is to set the foundations of the OpenAPI Gradle plugin with the necessary configurations. 

**High-level requirements:**
1. The plugin can be applied to Gradle projects.
2. The plugin is configured to use the default Mustache templates (SDK defaults)
3. The plugin allows users to override default templates.
4. The plugin allows users to override default configurations.

# Action
<!-- Summarize the key steps or decisions taken to accomplish the task. Include what changes were made in the codebase, architecture, or process. What actions were implemented to address the task? -->

1️⃣ Created `EgSdkOpenApiGeneratorPlugin` plugin entry point. This class applies the original OpenAPI gradle plugin and uses `OpenApiGeneratorConfigurator` to apply the default configurations.



2️⃣ Created `OpenApiGeneratorConfigurator` that holds the default SDK configurations. 



3️⃣ Created `MustacheTemplatesHandler` that handles extracting the Mustache templates from the plugin's JAR file and merge them with the user-provided templates - if needed. This utility places the final templates (defaults + user-provided) in `build/final_templates` directory. This directory is then passed to the OpenAPI plugin `templatesDir`. 

> [!NOTE]
> This class expects default templates to be placed in the plugin's resources under `templates` directory (`src/main/resources/templates`)

# Testing
<!-- Describe the testing strategy or approach used to validate the changes. Include any relevant test cases, scenarios, or data used to verify the work. How was the work tested? -->
Tested the plugin in a playground project and verified locally. More automated tests to be added after adding the templates.

**Tested Scenarios:**
1. The plugin can be applied to Gradle projects ✅ 
2. The plugin is configured to use the default Mustache templates (SDK defaults) ✅ 
3. The plugin allows users to override default templates ✅ 
4. The plugin allows users to override default configurations ✅ 

# Results
<!-- Detail the outcomes of the actions. What improvements or changes have been achieved? Include performance gains, bug fixes, or other tangible outcomes. How will you measure or verify success? -->
Product SDKs that applies this plugin will be able to generate models and operations from the provided spec file with minimal configurations and straightforward workflow.

**Apply with minimal configurations**
```groovy
openApiGenerate {
    inputSpec = "$rootDir/src/main/resources/openapi-spec.yaml"
    outputDir = "$buildDir/generated"
}
```

**Apply and override default templates**
```groovy
openApiGenerate {
    inputSpec = "$rootDir/src/main/resources/openapi-spec.yaml"
    outputDir = "$buildDir/generated"
    templateDir = "$rootDir/src/main/resources"
}
```

**Apply and override default configurations**
```groovy
openApiGenerate {
    inputSpec = "$rootDir/src/main/resources/openapi-spec.yaml"
    outputDir = "$buildDir/generated"
    templateDir = "$rootDir/src/main/resources"

    it.additionalProperties.set([
            "apiSuffix": "CustomOperation",
    ])
}
```