### PR TITLE
chore: add property constraint violation exception

### DIFF
--- a/expediagroup-sdk-rest/build.gradle
+++ b/expediagroup-sdk-rest/build.gradle
@@ -41,7 +41,8 @@ kover {
         filters {
             excludes {
                 packages(
-                        "com.expediagroup.sdk.rest.trait",
+                    "com.expediagroup.sdk.rest.trait",
+                    "com.expediagroup.sdk.rest.exception",
                 )
             }
         }

--- a/expediagroup-sdk-rest/src/main/kotlin/com/expediagroup/sdk/rest/exception/client/PropertyConstraintViolationException.kt
+++ b/expediagroup-sdk-rest/src/main/kotlin/com/expediagroup/sdk/rest/exception/client/PropertyConstraintViolationException.kt
@@ -1,0 +1,16 @@
+package com.expediagroup.sdk.rest.exception.client
+
+import com.expediagroup.sdk.core.exception.client.ExpediaGroupClientException
+
+/**
+ * An exception to be thrown when a constraint on some property has been violated.
+ *
+ * @property message The detail message.
+ * @property constraintViolations A list of the constraint violations that occurred
+ */
+class PropertyConstraintViolationException(
+    message: String = "Some field constraints have been violated",
+    constraintViolations: List<String>
+) : ExpediaGroupClientException(
+        "$message ${constraintViolations.joinToString(separator = ",\n\t- ", prefix = "[\n\t- ", postfix = "\n]")}"
+    )


### PR DESCRIPTION
# Situation
The `PropertyConstraintViolationException` class, which exists in the old `sdk-core`, needs to be migrated to the new `sdk-core`. The exception is thrown when any property constraint is violated by the end-user of the SDK when attempting to build requests.

# Task
Add the `PropertyConstraintViolationException` class to the new `sdk-core`.

# Action
- Added a new exception class `PropertyConstraintViolationException` in the package `com.expediagroup.sdk.rest.exception.client`.
- Updated the `build.gradle` file to exclude the new exception package from coverage.

# Testing
**NaN**

# Results
`PropertyConstraintViolationException` class is now available for consumption in the new `sdk-core`.

# Notes
**NaN**