### PR TITLE
chore: encode url query params separators

### DIFF
--- a/expediagroup-sdk-rest/src/main/kotlin/com/expediagroup/sdk/rest/util/UrlQueryParamUtils.kt
+++ b/expediagroup-sdk-rest/src/main/kotlin/com/expediagroup/sdk/rest/util/UrlQueryParamUtils.kt
@@ -17,6 +17,7 @@
 package com.expediagroup.sdk.rest.util
 
 import com.expediagroup.sdk.rest.model.UrlQueryParam
+import java.net.URLEncoder
 
 /**
  * Functional interface for converting a UrlQueryParam to a String.
@@ -39,7 +40,7 @@ val stringifyForm =
     StringifyQueryParam { param ->
         StringBuilder().apply {
             append("${param.key}=")
-            append(param.value.joinToString(","))
+            append(param.value.joinToString(URLEncoder.encode(",", "UTF-8")))
         }.toString()
     }
 
@@ -63,7 +64,7 @@ val stringifySpaceDelimited =
     StringifyQueryParam { param ->
         StringBuilder().apply {
             append("${param.key}=")
-            append(param.value.joinToString("%20"))
+            append(param.value.joinToString(URLEncoder.encode(" ", "UTF-8")))
         }.toString()
     }
 
@@ -75,7 +76,7 @@ val stringifyPipeDelimited =
     StringifyQueryParam { param ->
         StringBuilder().apply {
             append("${param.key}=")
-            append(param.value.joinToString("|"))
+            append(param.value.joinToString(URLEncoder.encode("|", "UTF-8")))
         }.toString()
     }
 

--- a/expediagroup-sdk-rest/src/test/kotlin/com/expediagroup/sdk/rest/util/UrlQueryParamUtilsTest.kt
+++ b/expediagroup-sdk-rest/src/test/kotlin/com/expediagroup/sdk/rest/util/UrlQueryParamUtilsTest.kt
@@ -28,7 +28,7 @@ class UrlQueryParamUtilsTest {
     @Test
     fun `stringifyForm should correctly convert UrlQueryParam to form-encoded String`() {
         val param = UrlQueryParam("myKey", listOf("v1", "v2"), stringifyForm)
-        val expectedString = "myKey=v1,v2"
+        val expectedString = "myKey=v1%2Cv2"
 
         val actualString = stringifyForm(param)
 
@@ -48,7 +48,7 @@ class UrlQueryParamUtilsTest {
     @Test
     fun `stringifySpaceDelimited should correctly convert UrlQueryParam to space-delimited String`() {
         val param = UrlQueryParam("myKey", listOf("v1", "v2"), stringifySpaceDelimited)
-        val expectedString = "myKey=v1%20v2"
+        val expectedString = "myKey=v1+v2"
 
         val actualString = stringifySpaceDelimited(param)
 
@@ -58,7 +58,7 @@ class UrlQueryParamUtilsTest {
     @Test
     fun `stringifyPipeDelimited should correctly convert UrlQueryParam to pipe-delimited String`() {
         val param = UrlQueryParam("myKey", listOf("v1", "v2"), stringifyPipeDelimited)
-        val expectedString = "myKey=v1|v2"
+        val expectedString = "myKey=v1%7Cv2"
 
         val actualString = stringifyPipeDelimited(param)
 


### PR DESCRIPTION
# Situation
The current implementation of URL query parameter encoding uses plain delimiters (commas, spaces, pipes) without encoding them. This can lead to issues when these characters are interpreted as special characters in URLs, causing incorrect query strings.

# Task
The goal is to update the URL encoding logic to ensure that delimiters are properly encoded. This will prevent issues with special characters in query strings and ensure that URLs are correctly interpreted by servers and clients.

# Action
- Updated `UrlQueryParamUtils.kt` to use `URLEncoder.encode` for encoding delimiters (commas, spaces, pipes) in query parameters.
- Modified the `stringifyForm`, `stringifySpaceDelimited`, and `stringifyPipeDelimited` functions to include proper encoding.
- Added the necessary import for `URLEncoder`.

# Testing
- Updated test cases in `UrlQueryParamUtilsTest.kt` to reflect the expected encoded strings.
- Verified that the changes produce correctly encoded query strings for form, space-delimited, and pipe-delimited formats.

# Results
- Delimiters in query parameters are now properly encoded, preventing issues with special characters in URLs.
- All test cases in `UrlQueryParamUtilsTest.kt` pass, confirming the correctness of the changes.

# Notes
- Related issue: [link to related issue if any]
- Follow-up tasks: Ensure that other parts of the codebase that handle URL query parameters are also updated if necessary.
- Potential risks: None identified.