### PR TITLE
feat: enable configurable masking and enable header masking

### DIFF
--- a/expediagroup-sdk-core/src/main/kotlin/com/expediagroup/sdk/core/logging/RequestLogger.kt
+++ b/expediagroup-sdk-core/src/main/kotlin/com/expediagroup/sdk/core/logging/RequestLogger.kt
@@ -16,6 +16,7 @@
 
 package com.expediagroup.sdk.core.logging
 
+import com.expediagroup.sdk.core.http.Headers
 import com.expediagroup.sdk.core.http.Request
 import com.expediagroup.sdk.core.http.RequestBody
 import com.expediagroup.sdk.core.logging.Constant.DEFAULT_MAX_BODY_SIZE
@@ -29,18 +30,19 @@ internal object RequestLogger {
         request: Request,
         vararg tags: String,
         maxBodyLogSize: Long? = null,
-        mask: (String) -> String = { it }
+        maskBody: (String) -> String = { it },
+        maskHeaders: (Headers) -> Headers = { it }
     ) {
         try {
             var logString =
                 buildString {
-                    append("URL=${request.url}, Method=${request.method}, Headers=[${request.headers}]")
+                    append("URL=${request.url}, Method=${request.method}, Headers=[${maskHeaders(request.headers)}]")
                 }
 
             if (logger.isDebugEnabled) {
                 val requestBodyString =
                     request.body?.let {
-                        mask(it.readLoggableBody(maxBodyLogSize, it.mediaType()?.charset))
+                        maskBody(it.readLoggableBody(maxBodyLogSize, it.mediaType()?.charset))
                     }
 
                 logString += ", Body=$requestBodyString"

--- a/expediagroup-sdk-core/src/main/kotlin/com/expediagroup/sdk/core/logging/ResponseLogger.kt
+++ b/expediagroup-sdk-core/src/main/kotlin/com/expediagroup/sdk/core/logging/ResponseLogger.kt
@@ -16,6 +16,7 @@
 
 package com.expediagroup.sdk.core.logging
 
+import com.expediagroup.sdk.core.http.Headers
 import com.expediagroup.sdk.core.http.Response
 import com.expediagroup.sdk.core.http.ResponseBody
 import com.expediagroup.sdk.core.logging.Constant.DEFAULT_MAX_BODY_SIZE
@@ -28,18 +29,19 @@ internal object ResponseLogger {
         response: Response,
         vararg tags: String,
         maxBodyLogSize: Long? = null,
-        mask: (String) -> String = { it }
+        maskBody: (String) -> String = { it },
+        maskHeaders: (Headers) -> Headers = { it }
     ) {
         try {
             var logString =
                 buildString {
-                    append("URL=${response.request.url}, Code=${response.status.code}, Headers=[${response.headers}]")
+                    append("URL=${response.request.url}, Code=${response.status.code}, Headers=[${maskHeaders(response.headers)}]")
                 }
 
             if (logger.isDebugEnabled) {
                 val responseBodyString =
                     response.body?.let {
-                        mask(it.readLoggableBody(maxBodyLogSize, it.mediaType()?.charset))
+                        maskBody(it.readLoggableBody(maxBodyLogSize, it.mediaType()?.charset))
                     }
 
                 logString += ", Body=$responseBodyString"

--- a/expediagroup-sdk-core/src/main/kotlin/com/expediagroup/sdk/core/logging/masking/MaskHeaders.kt
+++ b/expediagroup-sdk-core/src/main/kotlin/com/expediagroup/sdk/core/logging/masking/MaskHeaders.kt
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2025 Expedia, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.expediagroup.sdk.core.logging.masking
+
+import com.expediagroup.sdk.core.http.Headers
+import com.expediagroup.sdk.core.logging.Constant
+
+/**
+ * A class that masks specified headers in a `Headers` object.
+ *
+ * @property keys A list of header keys that should be masked.
+ */
+class MaskHeaders(
+    private val keys: List<String>
+) : (Headers) -> Headers {
+    /**
+     * Masks the specified headers in the given `Headers` object.
+     *
+     * @param headers The original `Headers` object.
+     * @return A new `Headers` object with the specified headers masked.
+     */
+    override fun invoke(headers: Headers): Headers =
+        headers.newBuilder().apply {
+            headers.names().filter { keys.contains(it) }.forEach { key ->
+                set(key, Constant.OMITTED)
+            }
+        }.build()
+}

--- a/expediagroup-sdk-core/src/main/kotlin/com/expediagroup/sdk/core/pipeline/step/RequestLoggingStep.kt
+++ b/expediagroup-sdk-core/src/main/kotlin/com/expediagroup/sdk/core/pipeline/step/RequestLoggingStep.kt
@@ -16,6 +16,7 @@
 
 package com.expediagroup.sdk.core.pipeline.step
 
+import com.expediagroup.sdk.core.http.Headers
 import com.expediagroup.sdk.core.http.Request
 import com.expediagroup.sdk.core.http.RequestBody
 import com.expediagroup.sdk.core.logging.LoggerDecorator
@@ -25,7 +26,9 @@ import okio.Buffer
 
 class RequestLoggingStep(
     private val logger: LoggerDecorator,
-    private val maxRequestBodySize: Long? = null
+    private val maxRequestBodySize: Long? = null,
+    private val maskBody: (String) -> String = { it },
+    private val maskHeaders: (Headers) -> Headers = { it }
 ) : RequestPipelineStep {
     override fun invoke(request: Request): Request {
         var reusableRequest: Request = request
@@ -38,7 +41,13 @@ class RequestLoggingStep(
                     .build()
         }
 
-        RequestLogger.log(logger, reusableRequest, maxBodyLogSize = maxRequestBodySize)
+        RequestLogger.log(
+            logger,
+            reusableRequest,
+            maxBodyLogSize = maxRequestBodySize,
+            maskBody = maskBody,
+            maskHeaders = maskHeaders
+        )
 
         return reusableRequest
     }

--- a/expediagroup-sdk-core/src/main/kotlin/com/expediagroup/sdk/core/pipeline/step/ResponseLoggingStep.kt
+++ b/expediagroup-sdk-core/src/main/kotlin/com/expediagroup/sdk/core/pipeline/step/ResponseLoggingStep.kt
@@ -16,13 +16,24 @@
 
 package com.expediagroup.sdk.core.pipeline.step
 
+import com.expediagroup.sdk.core.http.Headers
 import com.expediagroup.sdk.core.http.Response
 import com.expediagroup.sdk.core.logging.LoggerDecorator
 import com.expediagroup.sdk.core.logging.ResponseLogger
 import com.expediagroup.sdk.core.pipeline.ResponsePipelineStep
 
 class ResponseLoggingStep(
-    private val logger: LoggerDecorator
+    private val logger: LoggerDecorator,
+    private val maskBody: (String) -> String = { it },
+    private val maskHeaders: (Headers) -> Headers = { it }
 ) : ResponsePipelineStep {
-    override fun invoke(response: Response): Response = response.also { ResponseLogger.log(logger, it) }
+    override fun invoke(response: Response): Response =
+        response.also {
+            ResponseLogger.log(
+                logger,
+                it,
+                maskBody = maskBody,
+                maskHeaders = maskHeaders
+            )
+        }
 }

--- a/expediagroup-sdk-core/src/test/kotlin/com/expediagroup/sdk/core/logging/ResponseLoggerTest.kt
+++ b/expediagroup-sdk-core/src/test/kotlin/com/expediagroup/sdk/core/logging/ResponseLoggerTest.kt
@@ -1,6 +1,7 @@
 package com.expediagroup.sdk.core.logging
 
 import com.expediagroup.sdk.core.http.CommonMediaTypes
+import com.expediagroup.sdk.core.http.Headers
 import com.expediagroup.sdk.core.http.MediaType
 import com.expediagroup.sdk.core.http.Method
 import com.expediagroup.sdk.core.http.Protocol
@@ -351,7 +352,7 @@ class ResponseLoggerTest {
         val mockMasker = mockk<(String) -> String>(relaxed = true)
 
         // When
-        ResponseLogger.log(mockLogger, testResponse, mask = mockMasker)
+        ResponseLogger.log(mockLogger, testResponse, maskBody = mockMasker)
 
         // Expect
         verify(exactly = 1) {
@@ -360,7 +361,7 @@ class ResponseLoggerTest {
     }
 
     @Test
-    fun `should not call masker when debug level is not enabled`() {
+    fun `should not call body masker when debug level is not enabled`() {
         val json = """{"username":"john", "apiKey":"secret123", "email":"john@example.com", "password":"p@ssw0rd"}"""
         val buffer = Buffer().write(json.toByteArray())
 
@@ -383,7 +384,7 @@ class ResponseLoggerTest {
         val mockMasker = mockk<(String) -> String>(relaxed = true)
 
         // When
-        ResponseLogger.log(mockLogger, testResponse, mask = mockMasker)
+        ResponseLogger.log(mockLogger, testResponse, maskBody = mockMasker)
 
         // Expect
         verify(exactly = 0) {
@@ -392,7 +393,7 @@ class ResponseLoggerTest {
     }
 
     @Test
-    fun `should apply masker to logged messages`() {
+    fun `should apply body masker to logged messages`() {
         val json = """{"username":"john", "apiKey":"secret123", "email":"john@example.com", "password":"p@ssw0rd"}"""
         val buffer = Buffer().write(json.toByteArray())
 
@@ -418,7 +419,7 @@ class ResponseLoggerTest {
         }
 
         // When
-        ResponseLogger.log(mockLogger, testResponse, mask = mockMasker)
+        ResponseLogger.log(mockLogger, testResponse, maskBody = mockMasker)
 
         // Expect
         verify(exactly = 1) {
@@ -427,6 +428,47 @@ class ResponseLoggerTest {
                 "Incoming",
                 *anyVararg()
             )
+        }
+    }
+
+    @Test
+    fun `should apply headers masker to logged messages`() {
+        val json = """body"""
+        val buffer = Buffer().write(json.toByteArray())
+
+        val testResponse =
+            Response
+                .builder()
+                .protocol(Protocol.HTTP_1_1)
+                .status(Status.OK)
+                .request(
+                    Request
+                        .builder()
+                        .url("https://example.com")
+                        .method(Method.POST)
+                        .build()
+                ).addHeader("Content-Type", "application/json")
+                .body(ResponseBody.create(buffer, mediaType = MediaType.parse("application/json"), contentLength = buffer.size))
+                .build()
+
+        every { mockLogger.isDebugEnabled } returns false
+
+        val mockMasker: (Headers) -> Headers = {
+            Headers.builder().add("content-type", "application/json").build()
+        }
+
+        // When
+        ResponseLogger.log(mockLogger, testResponse, maskHeaders = mockMasker)
+
+        // Expect
+        verify(exactly = 1) {
+            mockLogger.info(
+                "URL=https://example.com, Code=200, Headers=[{content-type=[application/json]}]",
+                "Incoming",
+                *anyVararg()
+            )
+
+            mockMasker.invoke(testResponse.headers)
         }
     }
 }

--- a/expediagroup-sdk-core/src/test/kotlin/com/expediagroup/sdk/core/logging/masking/MaskHeadersTest.kt
+++ b/expediagroup-sdk-core/src/test/kotlin/com/expediagroup/sdk/core/logging/masking/MaskHeadersTest.kt
@@ -1,0 +1,42 @@
+package com.expediagroup.sdk.core.logging.masking
+
+import com.expediagroup.sdk.core.http.Headers
+import com.expediagroup.sdk.core.logging.Constant
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class MaskHeadersTest {
+    @Test
+    fun `handles empty headers`() {
+        val maskHeaders = MaskHeaders(emptyList())
+        val headers = maskHeaders(Headers.builder().build())
+        assertTrue(headers.entries().isEmpty())
+    }
+
+    @Test
+    fun `masks targeted headers only`() {
+        val maskedHeaders =
+            mapOf(
+                "authorization" to "Bearer token",
+                "key" to "private key"
+            )
+
+        val otherHeaders =
+            mapOf(
+                "content-type" to "application/json",
+                "accept" to "application/json"
+            )
+
+        MaskHeaders(maskedHeaders.keys.toList()).invoke(
+            Headers.builder().apply {
+                maskedHeaders.forEach { (key, value) -> add(key, value) }
+                otherHeaders.forEach { (key, value) -> add(key, value) }
+            }.build()
+        ).entries().forEach { (key, value) ->
+            when {
+                maskedHeaders.containsKey(key) -> assertTrue(value.size == 1 && value.first() == Constant.OMITTED)
+                else -> assertTrue(value.size == 1 && value.first() == otherHeaders[key])
+            }
+        }
+    }
+}


### PR DESCRIPTION
# Situation
The current logging mechanism does not mask sensitive information in headers of HTTP requests and responses. It also does not expose a configuration API for product SDKs to consume.

# Task
The goal is to enhance the logging functionality by introducing configurable mechanisms to mask sensitive information in HTTP headers and bodies.

# Action
- Introduced `maskBody` and `maskHeaders` functions to `RequestLogger` and `ResponseLogger` to allow masking of sensitive information.
- Updated the logging strings to use these masking functions.
- Created a new class `MaskHeaders` to handle header masking.
- Modified `RequestLoggingStep` and `ResponseLoggingStep` to incorporate the new masking mechanisms.
- Updated existing tests to accommodate the new masking functions and added new tests for the `MaskHeaders` class.

# Testing
- Updated unit tests for `RequestLogger` and `ResponseLogger` to verify the correct application of body and header masking.
- Added new unit tests for `MaskHeaders` to ensure that it correctly masks specified headers and handles cases with empty headers.

# Results
- Sensitive information in HTTP headers and bodies is now masked in logs.
- Exposed an API for configuring fields deemed for masking.

# Notes
**NaN**