### PR TITLE
chore: add allowed media types lambda

### DIFF
--- a/generator/openapi/src/main/kotlin/com/expediagroup/sdk/generators/openapi/MustacheHelpers.kt
+++ b/generator/openapi/src/main/kotlin/com/expediagroup/sdk/generators/openapi/MustacheHelpers.kt
@@ -147,15 +147,17 @@ val mustacheHelpers =
                 fragment.execute(context, writer)
             }
         },
-        "allowedMediaTypes" to Mustache.Lambda { fragment, writer ->
-            val response: CodegenResponse = fragment.context() as CodegenResponse
-            if (response.is2xx) {
-                val mediaTypes: List<String> = response.content.keys.filter {
-                    !it.contains("xml", ignoreCase = true)
-                }
+        "allowedMediaTypes" to {
+            Mustache.Lambda { fragment, writer ->
+                val response: CodegenResponse = fragment.context() as CodegenResponse
+                if (response.is2xx) {
+                    val mediaTypes: List<String> = response.content.keys.filter {
+                        !it.contains("xml", ignoreCase = true)
+                    }
 
-                val context = mapOf("mediaTypes" to mediaTypes)
-                fragment.execute(context, writer)
+                    val context = mapOf("mediaTypes" to mediaTypes)
+                    fragment.execute(context, writer)
+                }
             }
         }
     )

--- a/generator/openapi/src/main/kotlin/com/expediagroup/sdk/generators/openapi/MustacheHelpers.kt
+++ b/generator/openapi/src/main/kotlin/com/expediagroup/sdk/generators/openapi/MustacheHelpers.kt
@@ -151,9 +151,10 @@ val mustacheHelpers =
             Mustache.Lambda { fragment, writer ->
                 val response: CodegenResponse = fragment.context() as CodegenResponse
                 if (response.is2xx) {
-                    val mediaTypes: List<String> = response.content.keys.filter {
-                        !it.contains("xml", ignoreCase = true)
-                    }
+                    val mediaTypes: List<String> = response.content.keys
+                        .filter {
+                            !it.contains("xml", ignoreCase = true)
+                        }
 
                     val context = mapOf("mediaTypes" to mediaTypes)
                     fragment.execute(context, writer)

--- a/generator/openapi/src/main/kotlin/com/expediagroup/sdk/generators/openapi/MustacheHelpers.kt
+++ b/generator/openapi/src/main/kotlin/com/expediagroup/sdk/generators/openapi/MustacheHelpers.kt
@@ -146,5 +146,16 @@ val mustacheHelpers =
 
                 fragment.execute(context, writer)
             }
+        },
+        "allowedMediaTypes" to Mustache.Lambda { fragment, writer ->
+            val response: CodegenResponse = fragment.context() as CodegenResponse
+            if (response.is2xx) {
+                val mediaTypes: List<String> = response.content.keys.filter {
+                    !it.contains("xml", ignoreCase = true)
+                }
+
+                val context = mapOf("mediaTypes" to mediaTypes)
+                fragment.execute(context, writer)
+            }
         }
     )

--- a/generator/openapi/src/main/kotlin/com/expediagroup/sdk/generators/openapi/MustacheHelpers.kt
+++ b/generator/openapi/src/main/kotlin/com/expediagroup/sdk/generators/openapi/MustacheHelpers.kt
@@ -151,10 +151,11 @@ val mustacheHelpers =
             Mustache.Lambda { fragment, writer ->
                 val response: CodegenResponse = fragment.context() as CodegenResponse
                 if (response.is2xx) {
-                    val mediaTypes: List<String> = response.content.keys
-                        .filter {
-                            !it.contains("xml", ignoreCase = true)
-                        }
+                    val mediaTypes: List<String> =
+                        response.content.keys
+                            .filter {
+                                !it.contains("xml", ignoreCase = true)
+                            }
 
                     val context = mapOf("mediaTypes" to mediaTypes)
                     fragment.execute(context, writer)


### PR DESCRIPTION
# Situation
In the context of our current API operations, the `GetCarsListingsOperationParams` and `GetCarsDetailsOperationParams` are incorrectly generating an `Accept` header that requests both `JSON` and `XML` content types. This is causing unnecessary complications and potential issues when interacting with the API.

# Task
The goal of this change is to ensure that the `Accept` header only requests the `JSON` content type for the specified operations.

# Action
To accomplish this task, I have updated the `MustacheHelpers.kt` file to include a new `allowedMediaTypes` Mustache Lambda. This lambda filters out any `XML` content types from the `Accept` header, ensuring that only `JSON` content types are requested. The specific changes include:
- Adding a new Mustache Lambda to filter the media types.
- Ensuring the context for the fragment execution only includes the filtered media types.

# Testing
**NaN**

# Results
Fixes SDK-1718.

# Notes
**NaN**