### PR TITLE
chore: auto generated request id

### DIFF
--- a/expediagroup-sdk-core/src/main/kotlin/com/expediagroup/sdk/core/http/Request.kt
+++ b/expediagroup-sdk-core/src/main/kotlin/com/expediagroup/sdk/core/http/Request.kt
@@ -27,7 +27,7 @@ import java.util.UUID
  */
 @ConsistentCopyVisibility
 data class Request private constructor(
-    val id: UUID,
+    val id: UUID = UUID.randomUUID(),
     val method: Method,
     val url: URL,
     val headers: Headers,
@@ -44,7 +44,6 @@ data class Request private constructor(
      * Builder class for [Request].
      */
     class Builder {
-        private var id: UUID = UUID.randomUUID()
         private var method: Method? = null
         private var url: URL? = null
         private var headersBuilder: Headers.Builder = Headers.Builder()
@@ -61,7 +60,6 @@ data class Request private constructor(
          * @param request The request to copy data from.
          */
         constructor(request: Request) {
-            this.id = request.id
             this.method = request.method
             this.url = request.url
             this.headersBuilder = request.headers.newBuilder()
@@ -102,17 +100,6 @@ data class Request private constructor(
             apply {
                 val parsedUrl = URL(url)
                 this.url = parsedUrl
-            }
-
-        /**
-         * Sets the request id.
-         *
-         * @param id The request id.
-         * @return This builder.
-         */
-        fun id(id: UUID) =
-            apply {
-                this.id = id
             }
 
         /**
@@ -215,7 +202,6 @@ data class Request private constructor(
             val url = this.url ?: throw IllegalStateException("URL is required.")
 
             return Request(
-                id = id,
                 method = method,
                 url = url,
                 headers = headersBuilder.build(),

--- a/expediagroup-sdk-core/src/main/kotlin/com/expediagroup/sdk/core/http/Request.kt
+++ b/expediagroup-sdk-core/src/main/kotlin/com/expediagroup/sdk/core/http/Request.kt
@@ -18,6 +18,7 @@ package com.expediagroup.sdk.core.http
 
 import java.net.MalformedURLException
 import java.net.URL
+import java.util.UUID
 
 /**
  * Represents an immutable HTTP request.
@@ -26,6 +27,7 @@ import java.net.URL
  */
 @ConsistentCopyVisibility
 data class Request private constructor(
+    val id: UUID,
     val method: Method,
     val url: URL,
     val headers: Headers,
@@ -42,6 +44,7 @@ data class Request private constructor(
      * Builder class for [Request].
      */
     class Builder {
+        private var id: UUID = UUID.randomUUID()
         private var method: Method? = null
         private var url: URL? = null
         private var headersBuilder: Headers.Builder = Headers.Builder()
@@ -58,6 +61,7 @@ data class Request private constructor(
          * @param request The request to copy data from.
          */
         constructor(request: Request) {
+            this.id = request.id
             this.method = request.method
             this.url = request.url
             this.headersBuilder = request.headers.newBuilder()
@@ -98,6 +102,17 @@ data class Request private constructor(
             apply {
                 val parsedUrl = URL(url)
                 this.url = parsedUrl
+            }
+
+        /**
+         * Sets the request id.
+         *
+         * @param id The request id.
+         * @return This builder.
+         */
+        fun id(id: UUID) =
+            apply {
+                this.id = id
             }
 
         /**
@@ -200,6 +215,7 @@ data class Request private constructor(
             val url = this.url ?: throw IllegalStateException("URL is required.")
 
             return Request(
+                id = id,
                 method = method,
                 url = url,
                 headers = headersBuilder.build(),

--- a/expediagroup-sdk-core/src/test/kotlin/com/expediagroup/sdk/core/http/RequestTest.kt
+++ b/expediagroup-sdk-core/src/test/kotlin/com/expediagroup/sdk/core/http/RequestTest.kt
@@ -1,20 +1,18 @@
 package com.expediagroup.sdk.core.http
 
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertNull
-import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import java.net.MalformedURLException
 import java.net.URL
-import java.util.UUID
 
 class RequestTest {
     @Test
     fun `should build request instance with all properties`() {
         // Given
-        val id = UUID.randomUUID()
         val method = Method.POST
         val url = URL("https://example.com")
         val headers = Headers.Builder().add("Authorization", "Bearer token").build()
@@ -24,7 +22,6 @@ class RequestTest {
         val request =
             Request
                 .builder()
-                .id(id)
                 .method(method)
                 .url(url)
                 .headers(headers)
@@ -32,7 +29,6 @@ class RequestTest {
                 .build()
 
         // Expect
-        assertEquals(id, request.id)
         assertEquals(method, request.method)
         assertEquals(url, request.url)
         assertEquals("Bearer token", request.headers.get("Authorization"))
@@ -45,7 +41,6 @@ class RequestTest {
         val originalRequest =
             Request
                 .builder()
-                .id(UUID.randomUUID())
                 .method(Method.GET)
                 .url("https://example.com")
                 .addHeader("Content-Type", "application/json")
@@ -59,7 +54,6 @@ class RequestTest {
                 .build()
 
         // Expect
-        assertEquals(originalRequest.id, newRequest.id)
         assertEquals(Method.GET, newRequest.method)
         assertEquals(originalRequest.url, newRequest.url)
 
@@ -71,9 +65,9 @@ class RequestTest {
     }
 
     @Test
-    fun `request id is auto generated if not passed`() {
+    fun `request id changes when request is built based on another request instance`() {
         // Given
-        val request =
+        val firstRequest =
             Request
                 .builder()
                 .method(Method.GET)
@@ -81,9 +75,12 @@ class RequestTest {
                 .addHeader("Content-Type", "application/json")
                 .build()
 
+        val secondRequest = firstRequest.newBuilder().build()
+
         // Expect
-        assertNotNull(request.id)
-        assertTrue(request.id.toString().isNotBlank())
+        assertNotNull(firstRequest.id)
+        assertNotNull(secondRequest.id)
+        assertNotEquals(firstRequest.id, secondRequest.id)
     }
 
     @Test

--- a/expediagroup-sdk-core/src/test/kotlin/com/expediagroup/sdk/core/http/RequestTest.kt
+++ b/expediagroup-sdk-core/src/test/kotlin/com/expediagroup/sdk/core/http/RequestTest.kt
@@ -1,16 +1,20 @@
 package com.expediagroup.sdk.core.http
 
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import java.net.MalformedURLException
 import java.net.URL
+import java.util.UUID
 
 class RequestTest {
     @Test
     fun `should build request instance with all properties`() {
         // Given
+        val id = UUID.randomUUID()
         val method = Method.POST
         val url = URL("https://example.com")
         val headers = Headers.Builder().add("Authorization", "Bearer token").build()
@@ -20,6 +24,7 @@ class RequestTest {
         val request =
             Request
                 .builder()
+                .id(id)
                 .method(method)
                 .url(url)
                 .headers(headers)
@@ -27,6 +32,7 @@ class RequestTest {
                 .build()
 
         // Expect
+        assertEquals(id, request.id)
         assertEquals(method, request.method)
         assertEquals(url, request.url)
         assertEquals("Bearer token", request.headers.get("Authorization"))
@@ -39,6 +45,7 @@ class RequestTest {
         val originalRequest =
             Request
                 .builder()
+                .id(UUID.randomUUID())
                 .method(Method.GET)
                 .url("https://example.com")
                 .addHeader("Content-Type", "application/json")
@@ -52,6 +59,7 @@ class RequestTest {
                 .build()
 
         // Expect
+        assertEquals(originalRequest.id, newRequest.id)
         assertEquals(Method.GET, newRequest.method)
         assertEquals(originalRequest.url, newRequest.url)
 
@@ -60,6 +68,22 @@ class RequestTest {
 
         assertEquals("application/json", newRequest.headers.get("Content-Type"))
         assertEquals("text/plain", newRequest.headers.get("Accept"))
+    }
+
+    @Test
+    fun `request id is auto generated if not passed`() {
+        // Given
+        val request =
+            Request
+                .builder()
+                .method(Method.GET)
+                .url("https://example.com")
+                .addHeader("Content-Type", "application/json")
+                .build()
+
+        // Expect
+        assertNotNull(request.id)
+        assertTrue(request.id.toString().isNotBlank())
     }
 
     @Test


### PR DESCRIPTION
# Situation
The current implementation of the `Request` class in the `expediagroup-sdk-core` module does not have a unique identifier for each request, which makes it difficult to track individual requests.

# Task
The goal of this change is to add a unique identifier (UUID) to each `Request` instance to improve request tracking and management. Request unique identifiers can be used as transaction unique identifiers if desired by the product SDK through configurable pipeline steps.

# Action
- Added a new property `id` of type `UUID` to the `Request` data class.
- Updated the `Request.Builder` class to initialize the `id` with a random UUID by default.
- Added a method `id(UUID)` to the `Request.Builder` to allow setting a custom UUID.
- Updated the `Request.Builder` copy constructor to include the `id` property.
- Modified the `build()` method to include the `id` when creating a new `Request` instance.
- Added new test cases in `RequestTest.kt` to validate the `id` property and ensure it is correctly set and auto-generated when not provided.

# Testing
- Added test cases to verify that the `id` property is correctly set when a custom UUID is provided to the builder.
- Added test cases to verify that the `id` property is auto-generated when not explicitly set.
- Ensured existing test cases for the `Request` class are still passing.

# Results
- Each `Request` instance now has a unique identifier, making it easier to track and manage individual requests.
- The new `id` property is validated through additional test cases to ensure it works as expected.

# Notes
- This change improves the traceability and management of HTTP requests within the SDK.
- No breaking changes are introduced as the new `id` property is added in a backward-compatible manner.
- Follow-up tasks might include updating documentation to reflect the new `id` property and any related examples or guidelines.