### PR TITLE
chore: add last-release-sha to release-please-config.json

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -5,6 +5,7 @@
   "include-component-in-tag": true,
   "bump-minor-pre-major": true,
   "bump-patch-for-minor-pre-major": true,
+  "last-release-sha": "edca48e129eb1ad0c7d4b65a0ff70107ccf33a63",
   "packages": {
     "expediagroup-sdk-core": {
       "path": "expediagroup-sdk-core",


### PR DESCRIPTION
# Situation
<!-- Describe the background or context leading to this change. Include why this work is needed (e.g., a specific problem, user need, or opportunity). What is the current state or issue that prompted this PR? -->
Release please PRs seems to be including commits older than the configured `bootstrap-sha`. In this PR, we attempt to prevent this behavior by adding `last-release-sha`.

> last-release-sha: For any release, only consider as far back as this commit SHA
