### PR TITLE
fix: rename BasicCredentials to BasicAuthCredentials

### DIFF
--- a/expediagroup-sdk-core/src/main/kotlin/com/expediagroup/sdk/core/auth/basic/BasicAuthCredentials.kt
+++ b/expediagroup-sdk-core/src/main/kotlin/com/expediagroup/sdk/core/auth/basic/BasicAuthCredentials.kt
@@ -18,9 +18,9 @@ package com.expediagroup.sdk.core.auth.basic
 
 import com.expediagroup.sdk.core.auth.common.Credentials
 
-data class BasicCredentials(
+data class BasicAuthCredentials(
     val username: String,
     val password: String
 ) : Credentials {
-    override fun toString(): String = "BasicCredentials(username=***, password=***)"
+    override fun toString(): String = "BasicAuthCredentials(username=***, password=***)"
 }

--- a/expediagroup-sdk-core/src/main/kotlin/com/expediagroup/sdk/core/auth/basic/BasicAuthManager.kt
+++ b/expediagroup-sdk-core/src/main/kotlin/com/expediagroup/sdk/core/auth/basic/BasicAuthManager.kt
@@ -20,13 +20,13 @@ import com.expediagroup.sdk.core.auth.common.AuthManager
 import com.expediagroup.sdk.core.auth.common.encodeBasic
 
 /**
- * Manages Basic Authentication by encoding the given [BasicCredentials] and providing
+ * Manages Basic Authentication by encoding the given [BasicAuthCredentials] and providing
  * an authorization header value for requests.
  *
  * @property credentials The user's credentials that will be encoded for authentication.
  */
 class BasicAuthManager(
-    private val credentials: BasicCredentials
+    private val credentials: BasicAuthCredentials
 ) : AuthManager {
     /**
      * A cached version of the encoded credentials, or `null` if not yet encoded.

--- a/expediagroup-sdk-core/src/test/kotlin/com/expediagroup/sdk/core/auth/basic/BasicAuthManagerTest.kt
+++ b/expediagroup-sdk-core/src/test/kotlin/com/expediagroup/sdk/core/auth/basic/BasicAuthManagerTest.kt
@@ -19,7 +19,7 @@ class BasicAuthManagerTest {
     @Test
     fun `should encode the provided credentials`() {
         // Given
-        val credentials = BasicCredentials("key", "secret")
+        val credentials = BasicAuthCredentials("key", "secret")
         val basicAuthManager = BasicAuthManager(credentials)
 
         // When
@@ -32,7 +32,7 @@ class BasicAuthManagerTest {
     @Test
     fun `should clear the cached encoded credentials`() {
         // Given
-        val credentials = BasicCredentials("key", "secret")
+        val credentials = BasicAuthCredentials("key", "secret")
         val basicAuthManager = BasicAuthManager(credentials)
 
         // When & Expect
@@ -46,7 +46,7 @@ class BasicAuthManagerTest {
     fun `should not re-encode the credentials once cached`() {
         // Given
         mockkStatic("com.expediagroup.sdk.core.auth.common.AuthUtilsKt")
-        val mockCredentials = mockk<BasicCredentials>(relaxed = true)
+        val mockCredentials = mockk<BasicAuthCredentials>(relaxed = true)
 
         val basicAuthManager = BasicAuthManager(mockCredentials)
 

--- a/expediagroup-sdk-core/src/test/kotlin/com/expediagroup/sdk/core/auth/basic/BasicCredentialsTest.kt
+++ b/expediagroup-sdk-core/src/test/kotlin/com/expediagroup/sdk/core/auth/basic/BasicCredentialsTest.kt
@@ -6,8 +6,8 @@ import org.junit.jupiter.api.Test
 class BasicCredentialsTest {
     @Test
     fun `toString should not print secret`() {
-        val credentials = BasicCredentials(username = "username", password = "password")
+        val credentials = BasicAuthCredentials(username = "username", password = "password")
 
-        assertEquals("BasicCredentials(username=***, password=***)", credentials.toString())
+        assertEquals("BasicAuthCredentials(username=***, password=***)", credentials.toString())
     }
 }

--- a/expediagroup-sdk-graphql/build.gradle
+++ b/expediagroup-sdk-graphql/build.gradle
@@ -21,7 +21,7 @@ dependencies {
     api 'com.apollographql.apollo:apollo-api:4.1.1'
 
     /* EG SDK Core */
-    api(project(":expediagroup-sdk-core"))
+    api 'com.expediagroup:expediagroup-sdk-core:0.0.6-alpha'
 
     /* Testing */
     testImplementation platform('org.junit:junit-bom:5.11.4')

--- a/expediagroup-sdk-rest/build.gradle
+++ b/expediagroup-sdk-rest/build.gradle
@@ -21,7 +21,7 @@ dependencies {
     implementation 'com.fasterxml.jackson.module:jackson-module-kotlin:2.18.2'
 
     /* EG SDK Core */
-    api(project(":expediagroup-sdk-core"))
+    api 'com.expediagroup:expediagroup-sdk-core:0.0.6-alpha'
 
     /* Testing */
     testImplementation platform('org.junit:junit-bom:5.11.4')

--- a/expediagroup-sdk-transport-okhttp/build.gradle
+++ b/expediagroup-sdk-transport-okhttp/build.gradle
@@ -18,7 +18,7 @@ dependencies {
 
     /* EG SDK Core */
     api 'com.squareup.okhttp3:okhttp:4.12.0'
-    compileOnly(project(":expediagroup-sdk-core"))
+    compileOnly 'com.expediagroup:expediagroup-sdk-core:0.0.6-alpha'
 
     /* Testing */
     testImplementation platform('org.junit:junit-bom:5.11.4')


### PR DESCRIPTION
# Situation
<!-- Describe the background or context leading to this change. Include why this work is needed (e.g., a specific problem, user need, or opportunity). What is the current state or issue that prompted this PR? -->
To align with the exiting naming pattern `*Auth*`, we need to rename `BasicCredentials` model to `BasicAuthCredentials`.

# Action
<!-- Summarize the key steps or decisions taken to accomplish the task. Include what changes were made in the codebase, architecture, or process. What actions were implemented to address the task? -->
1. Rename `BasicCredentials` models to `BasicAuthCredentials`.
2. Reverted to fixed-versions dependencies between internal modules until we figure out more robust publishing workflow.

# Testing
<!-- Describe the testing strategy or approach used to validate the changes. Include any relevant test cases, scenarios, or data used to verify the work. How was the work tested? -->
Updated all related tests
