### PR TITLE
fix(expediagroup-sdk-rest): use expediagroup-sdk-core:0.0.7-alpha 

### DIFF
--- a/expediagroup-sdk-rest/build.gradle
+++ b/expediagroup-sdk-rest/build.gradle
@@ -21,7 +21,7 @@ dependencies {
     implementation 'com.fasterxml.jackson.module:jackson-module-kotlin:2.18.2'
 
     /* EG SDK Core */
-    api 'com.expediagroup:expediagroup-sdk-core:0.0.6-alpha'
+    api 'com.expediagroup:expediagroup-sdk-core:0.0.7-alpha'
 
     /* Testing */
     testImplementation platform('org.junit:junit-bom:5.11.4')


### PR DESCRIPTION
# Situation
<!-- Describe the background or context leading to this change. Include why this work is needed (e.g., a specific problem, user need, or opportunity). What is the current state or issue that prompted this PR? -->
Update the core dependency version in the rest module to `0.0.7-alpha`
