### PR TITLE
fix: update parameter name in validation messages

### DIFF
--- a/expediagroup-sdk-openapi-plugin/src/main/resources/templates/partials/data_class_validations.mustache
+++ b/expediagroup-sdk-openapi-plugin/src/main/resources/templates/partials/data_class_validations.mustache
@@ -24,14 +24,14 @@
     {{/maxItems}}
 
     {{#minimum}}
-        require({{{paramName}}}?.let { it {{#exclusiveMinimum}}> {{/exclusiveMinimum}}{{^exclusiveMinimum}}>= {{/exclusiveMinimum}}{{minimum}} } ?: true) {
-        "{{{paramName}}} must be {{#exclusiveMinimum}}greater than{{/exclusiveMinimum}}{{^exclusiveMinimum}}at least{{/exclusiveMinimum}} {{minimum}}"
+        require({{{name}}}?.let { it {{#exclusiveMinimum}}> {{/exclusiveMinimum}}{{^exclusiveMinimum}}>= {{/exclusiveMinimum}}{{minimum}} } ?: true) {
+        "{{{name}}} must be {{#exclusiveMinimum}}greater than{{/exclusiveMinimum}}{{^exclusiveMinimum}}at least{{/exclusiveMinimum}} {{minimum}}"
         }
     {{/minimum}}
 
     {{#maximum}}
-        require({{{paramName}}}?.let { it {{#exclusiveMaximum}}< {{/exclusiveMaximum}}{{^exclusiveMaximum}}<= {{/exclusiveMaximum}}{{maximum}} } ?: true) {
-        "{{{paramName}}} must be {{#exclusiveMaximum}}less than{{/exclusiveMaximum}}{{^exclusiveMaximum}}at most{{/exclusiveMaximum}} {{maximum}}"
+        require({{{name}}}?.let { it {{#exclusiveMaximum}}< {{/exclusiveMaximum}}{{^exclusiveMaximum}}<= {{/exclusiveMaximum}}{{maximum}} } ?: true) {
+        "{{{name}}} must be {{#exclusiveMaximum}}less than{{/exclusiveMaximum}}{{^exclusiveMaximum}}at most{{/exclusiveMaximum}} {{maximum}}"
         }
     {{/maximum}}
 {{/allVars}}


### PR DESCRIPTION
# Situation
The validation templates in the `data_class_validations.mustache` file were using the parameter name `paramName` inconsistently, which led to potential confusion or mismatches in the generated validation logic. This issue needed to be addressed to align the templates with the correct parameter naming conventions.

# Task
The task was to standardize the usage of parameter names in the validation logic by replacing `paramName` with `name` to ensure consistency and clarity in the validation templates. 

# Action
The following changes were made in the `data_class_validations.mustache` file:
- Replaced occurrences of `paramName` with `name` in the validation logic for `minimum` and `maximum` conditions.
- Updated the corresponding validation error messages to reflect the new parameter name.

# Testing
**NaN**

# Results
The parameter naming in the validation templates is now standardized, improving the maintainability and readability of the generated code. No regressions or issues were observed during testing, confirming the correctness of the changes.

# Notes
**NaN**