### PR TITLE
feat: new links model utilities

### DIFF
--- a/expediagroup-sdk-openapi-plugin/src/main/kotlin/com/expediagroup/sdk/openapigenerator/util/OpenApiGeneratorConfigurator.kt
+++ b/expediagroup-sdk-openapi-plugin/src/main/kotlin/com/expediagroup/sdk/openapigenerator/util/OpenApiGeneratorConfigurator.kt
@@ -153,7 +153,8 @@ object OpenApiGeneratorConfigurator {
         val defaultAdditionalProps =
             mapOf(
                 "namespace" to product.namespace,
-                "apiSuffix" to "Operation"
+                "apiSuffix" to "Operation",
+                "jacksonObjectMapper" to "${product.packageName}.configuration.OBJECT_MAPPER",
             )
 
         val userAdditionalProps = ext.additionalProperties.orNull ?: emptyMap<String, Any>()

--- a/expediagroup-sdk-openapi-plugin/src/main/resources/templates/operation_params.mustache
+++ b/expediagroup-sdk-openapi-plugin/src/main/resources/templates/operation_params.mustache
@@ -43,6 +43,10 @@ package com.expediagroup.sdk.{{namespace}}.operations
                 {{>operations/params/get_query_params}}
 
                 {{>operations/params/get_path_params}}
+
+                {{#link}}
+                    {{>operations/params/link_builder_method}}
+                {{/link}}
                 }
             {{/hasNonBodyParams}}
         {{/processOperation}}

--- a/expediagroup-sdk-openapi-plugin/src/main/resources/templates/operations/params/link_builder_method.mustache
+++ b/expediagroup-sdk-openapi-plugin/src/main/resources/templates/operations/params/link_builder_method.mustache
@@ -5,7 +5,7 @@ fun withLink(link: {{#linkType}}{{{.}}}{{/linkType}}) = apply {
 
 {{#hasPathParams}}
     if (path != null) {
-        val pathParams: Map<String, String> = com.expediagroup.sdk.rest.util.parseUrlPathTemplateParams(
+        val pathParams: Map<String, String> = com.expediagroup.sdk.rest.util.UrlUtils.parsePathParams(
             path = path,
             template = """{{{path}}}"""
         )
@@ -25,7 +25,7 @@ fun withLink(link: {{#linkType}}{{{.}}}{{/linkType}}) = apply {
     {{#queryParams}}"{{{baseName}}}" to "{{collectionFormat}}"{{/queryParams}}
     )
     if (query != null) {
-        val queryParams = com.expediagroup.sdk.rest.util.parseUrlQueryParamsFromQuery(
+        val queryParams = com.expediagroup.sdk.rest.util.UrlUtils.parseQueryParams(
             query = query,
             destringifyStrategies = destringifyStrategies,
         )
@@ -33,7 +33,7 @@ fun withLink(link: {{#linkType}}{{{.}}}{{/linkType}}) = apply {
     {{#queryParams}}
         if (queryParams.containsKey("{{{baseName}}}") {
             queryParams["{{{baseName}}}"]?.takeIf { it.isNotEmpty() }?.let { values: List<String> ->
-                this.{{{paramName}}} = com.expediagroup.sdk.rest.util.resolveUrlQueryParamValuesType<{{>partials/datatype}}>(
+                this.{{{paramName}}} = com.expediagroup.sdk.rest.util.UrlUtils.resolveUrlQueryParamValuesType<{{>partials/datatype}}>(
                     values = values,
                     objectMapper = {{{jacksonObjectMapper}}},
                     typeRef = com.fasterxml.jackson.module.kotlin.jacksonTypeRef<{{>partials/datatype}}>(),

--- a/expediagroup-sdk-openapi-plugin/src/main/resources/templates/operations/params/link_builder_method.mustache
+++ b/expediagroup-sdk-openapi-plugin/src/main/resources/templates/operations/params/link_builder_method.mustache
@@ -33,7 +33,7 @@ fun withLink(link: {{#linkType}}{{{.}}}{{/linkType}}) = apply {
     {{#queryParams}}
         if (queryParams.containsKey("{{{baseName}}}") {
             queryParams["{{{baseName}}}"]?.takeIf { it.isNotEmpty() }?.let { values: List<String> ->
-                this.{{{paramName}}} = com.expediagroup.sdk.rest.util.resolveUrlQueryParamValuesType(
+                this.{{{paramName}}} = com.expediagroup.sdk.rest.util.resolveUrlQueryParamValuesType<{{>partials/datatype}}>(
                     values = values,
                     objectMapper = {{{jacksonObjectMapper}}},
                     typeRef = com.fasterxml.jackson.module.kotlin.jacksonTypeRef<{{>partials/datatype}}>(),

--- a/expediagroup-sdk-openapi-plugin/src/main/resources/templates/operations/params/link_builder_method.mustache
+++ b/expediagroup-sdk-openapi-plugin/src/main/resources/templates/operations/params/link_builder_method.mustache
@@ -1,0 +1,46 @@
+fun withLink(link: {{#linkType}}{{{.}}}{{/linkType}}) = apply {
+    val url = link.href.trim().split("?", limit = 2)
+    val path = url.getOrNull(0)
+    val query = url.getOrNull(1)
+
+{{#hasPathParams}}
+    if (path != null) {
+        val pathParams: Map<String, String> = com.expediagroup.sdk.rest.util.parseUrlPathTemplateParams(
+            path = path,
+            template = """{{{path}}}"""
+        )
+
+        {{#pathParams}}
+            if (pathParams.containsKey("{{{baseName}}}") {
+                pathParams["{{{baseName}}}"].takeIf { it.isNotBlank() }?.let {
+                    this.{{{paramName}}} = {{{jacksonObjectMapper}}}.convertValue(it, jacksonTypeRef<{{>partials/datatype}}>())
+                }
+            }
+        {{/pathParams}}
+    }
+{{/hasPathParams}}
+
+{{#hasQueryParams}}
+    val destringifyStrategies = mapOf<String, String>(
+    {{#queryParams}}"{{{baseName}}}" to "{{collectionFormat}}"{{/queryParams}}
+    )
+    if (query != null) {
+        val queryParams = com.expediagroup.sdk.rest.util.parseUrlQueryParamsFromQuery(
+            query = query,
+            destringifyStrategies = destringifyStrategies,
+        )
+
+    {{#queryParams}}
+        if (queryParams.containsKey("{{{baseName}}}") {
+            queryParams["{{{baseName}}}"]?.takeIf { it.isNotEmpty() }?.let { values: List<String> ->
+                this.{{{paramName}}} = com.expediagroup.sdk.rest.util.resolveUrlQueryParamValuesType(
+                    values = values,
+                    objectMapper = {{{jacksonObjectMapper}}},
+                    typeRef = com.fasterxml.jackson.module.kotlin.jacksonTypeRef<{{>partials/datatype}}>(),
+                )
+            }
+        }
+    {{/queryParams}}
+    }
+{{/hasQueryParams}}
+}

--- a/expediagroup-sdk-rest/src/main/kotlin/com/expediagroup/sdk/rest/util/UrlQueryParamUtils.kt
+++ b/expediagroup-sdk-rest/src/main/kotlin/com/expediagroup/sdk/rest/util/UrlQueryParamUtils.kt
@@ -32,12 +32,20 @@ fun interface StringifyQueryParam : (UrlQueryParam) -> String {
     override fun invoke(queryParam: UrlQueryParam): String
 }
 
+/**
+ * Functional interface for converting a string representation of a query parameter
+ * into a `UrlQueryParam` object.
+ *
+ * This interface takes two input strings: the name of the query parameter and its value,
+ * and returns a `UrlQueryParam` object that represents the parsed query parameter.
+ */
 fun interface DestringifyQueryParam : (String, String) -> UrlQueryParam {
     /**
-     * Converts the given String to a list of values.
+     * Converts the given query parameter name and value into a `UrlQueryParam` object.
      *
-     * @param query the String to convert
-     * @return the list of values extracted from the String
+     * @param name The name of the query parameter.
+     * @param query The string representation of the query parameter's value.
+     * @return A `UrlQueryParam` object representing the parsed query parameter.
      */
     override fun invoke(
         name: String,
@@ -45,120 +53,109 @@ fun interface DestringifyQueryParam : (String, String) -> UrlQueryParam {
     ): UrlQueryParam
 }
 
-class UrlQueryParamStringifiers {
-    companion object {
-        /**
-         * Converts a UrlQueryParam to a form-encoded String.
-         * Example: key=value1,value2
-         */
-        val stringifyForm =
-            StringifyQueryParam { param ->
-                StringBuilder().apply {
-                    append("${param.key}=")
-                    append(param.value.joinToString(URLEncoder.encode(",", "UTF-8")))
-                }.toString()
-            }
+object UrlQueryParamStringifier {
+    /**
+     * Converts a UrlQueryParam to a form-encoded String.
+     * Example: key=value1,value2
+     */
+    val form =
+        StringifyQueryParam { param ->
+            StringBuilder().apply {
+                append("${param.key}=")
+                append(param.value.joinToString(URLEncoder.encode(",", "UTF-8")))
+            }.toString()
+        }
 
-        /**
-         * Converts a UrlQueryParam to an exploded form-encoded String.
-         * Example: key=value1&key=value2
-         */
-        val stringifyExplode =
-            StringifyQueryParam { param ->
-                StringBuilder().apply {
-                    append("${param.key}=")
-                    append(param.value.joinToString("&${param.key}="))
-                }.toString()
-            }
+    /**
+     * Converts a UrlQueryParam to an exploded form-encoded String.
+     * Example: key=value1&key=value2
+     */
+    val explode =
+        StringifyQueryParam { param ->
+            StringBuilder().apply {
+                append("${param.key}=")
+                append(param.value.joinToString("&${param.key}="))
+            }.toString()
+        }
 
-        /**
-         * Converts a UrlQueryParam to a space-delimited String.
-         * Example: key=value1%20value2
-         */
-        val stringifySpaceDelimited =
-            StringifyQueryParam { param ->
-                StringBuilder().apply {
-                    append("${param.key}=")
-                    append(param.value.joinToString(URLEncoder.encode(" ", "UTF-8")))
-                }.toString()
-            }
+    /**
+     * Converts a UrlQueryParam to a space-delimited String.
+     * Example: key=value1%20value2
+     */
+    val spaceDelimited =
+        StringifyQueryParam { param ->
+            StringBuilder().apply {
+                append("${param.key}=")
+                append(param.value.joinToString(URLEncoder.encode(" ", "UTF-8")))
+            }.toString()
+        }
 
-        /**
-         * Converts a UrlQueryParam to a pipe-delimited String.
-         * Example: key=value1|value2
-         */
-        val stringifyPipeDelimited =
-            StringifyQueryParam { param ->
-                StringBuilder().apply {
-                    append("${param.key}=")
-                    append(param.value.joinToString(URLEncoder.encode("|", "UTF-8")))
-                }.toString()
-            }
-    }
+    /**
+     * Converts a UrlQueryParam to a pipe-delimited String.
+     * Example: key=value1|value2
+     */
+    val pipeDelimited =
+        StringifyQueryParam { param ->
+            StringBuilder().apply {
+                append("${param.key}=")
+                append(param.value.joinToString(URLEncoder.encode("|", "UTF-8")))
+            }.toString()
+        }
 }
 
-class UrlQueryParamDestringifiers {
-    companion object {
-        /**
-         * Destringifies a form-encoded query string into a list of values.
-         *
-         * @param query The form-encoded query string.
-         * @return A list of values extracted from the query string.
-         */
-        val destringifyForm =
-            DestringifyQueryParam { name: String, value: String ->
-                UrlQueryParam(
-                    key = name,
-                    value = value.split(",").filter(String::isNotBlank),
-                    stringify = UrlQueryParamStringifiers.stringifyForm
-                )
-            }
+object UrlQueryParamDestringifiers {
+    /**
+     * Converts a string representation of a query parameter in "form" format
+     * (comma-separated values) into a `UrlQueryParam` object.
+     */
+    val form =
+        DestringifyQueryParam { name: String, value: String ->
+            UrlQueryParam(
+                key = name,
+                value = value.split(",").filter(String::isNotBlank),
+                stringify = UrlQueryParamStringifier.form
+            )
+        }
 
-        /**
-         * Destringifies an exploded form-encoded query string into a list of values.
-         *
-         * @param query The exploded form-encoded query string.
-         * @return A list of values extracted from the query string.
-         */
-        val destringifyExplode =
-            DestringifyQueryParam { name: String, value: String ->
-                UrlQueryParam(
-                    key = name,
-                    value = value.split("&").filter(String::isNotBlank),
-                    stringify = UrlQueryParamStringifiers.stringifyExplode
-                )
-            }
+    /**
+     * Converts a string representation of a query parameter in "explode" format
+     * (multiple key-value pairs separated by '&') into a `UrlQueryParam` object.
+     *
+     */
+    val explode =
+        DestringifyQueryParam { name: String, value: String ->
+            UrlQueryParam(
+                key = name,
+                value = value.split("&").filter(String::isNotBlank),
+                stringify = UrlQueryParamStringifier.explode
+            )
+        }
 
-        /**
-         * Destringifies a space-delimited query string into a list of values.
-         *
-         * @param query The space-delimited query string.
-         * @return A list of values extracted from the query string.
-         */
-        val destringifySpaceDelimited =
-            DestringifyQueryParam { name: String, value: String ->
-                UrlQueryParam(
-                    key = name,
-                    value = value.split(" ").filter(String::isNotBlank),
-                    stringify = UrlQueryParamStringifiers.stringifySpaceDelimited
-                )
-            }
+    /**
+     * Converts a string representation of a query parameter in "space-delimited" format
+     * (values separated by spaces) into a `UrlQueryParam` object.
+     */
+    val spaceDelimited =
+        DestringifyQueryParam { name: String, value: String ->
+            UrlQueryParam(
+                key = name,
+                value = value.split(" ").filter(String::isNotBlank),
+                stringify = UrlQueryParamStringifier.spaceDelimited
+            )
+        }
 
-        /**
-         * Destringifies a pipe-delimited query string into a list of values.
-         *
-         * @param query The pipe-delimited query string.
-         * @return A list of values extracted from the query string.
-         */
-        val destringifyPipeDelimited =
-            DestringifyQueryParam { name: String, value: String ->
-                UrlQueryParam(
-                    key = name,
-                    value = value.split("|").filter(String::isNotBlank),
-                    stringify = UrlQueryParamStringifiers.stringifyPipeDelimited
-                )
-            }
-    }
+    /**
+     * Converts a string representation of a query parameter in "pipe-delimited" format
+     * (values separated by '|') into a `UrlQueryParam` object.
+     */
+    val pipeDelimited =
+        DestringifyQueryParam { name: String, value: String ->
+            UrlQueryParam(
+                key = name,
+                value = value.split("|").filter(String::isNotBlank),
+                stringify = UrlQueryParamStringifier.pipeDelimited
+            )
+        }
 }
 
 /**
@@ -172,13 +169,12 @@ class UrlQueryParamDestringifiers {
  * - "pipes": Pipe-separated values (e.g., key=value1|value2)
  * - "multi": Multiple key-value pairs (e.g., key=value1&key=value2)
  */
-@Suppress("unused")
 val swaggerCollectionFormatStringifier =
     mapOf(
-        "csv" to UrlQueryParamStringifiers.stringifyForm,
-        "ssv" to UrlQueryParamStringifiers.stringifySpaceDelimited,
-        "pipes" to UrlQueryParamStringifiers.stringifyPipeDelimited,
-        "multi" to UrlQueryParamStringifiers.stringifyExplode
+        "csv" to UrlQueryParamStringifier.form,
+        "ssv" to UrlQueryParamStringifier.spaceDelimited,
+        "pipes" to UrlQueryParamStringifier.pipeDelimited,
+        "multi" to UrlQueryParamStringifier.explode
     )
 
 /**
@@ -194,8 +190,8 @@ val swaggerCollectionFormatStringifier =
  */
 val swaggerCollectionFormatDestringifier: Map<String, DestringifyQueryParam> =
     mapOf(
-        "csv" to UrlQueryParamDestringifiers.destringifyForm,
-        "ssv" to UrlQueryParamDestringifiers.destringifySpaceDelimited,
-        "pipes" to UrlQueryParamDestringifiers.destringifyPipeDelimited,
-        "multi" to UrlQueryParamDestringifiers.destringifyExplode
+        "csv" to UrlQueryParamDestringifiers.form,
+        "ssv" to UrlQueryParamDestringifiers.spaceDelimited,
+        "pipes" to UrlQueryParamDestringifiers.pipeDelimited,
+        "multi" to UrlQueryParamDestringifiers.explode
     )

--- a/expediagroup-sdk-rest/src/main/kotlin/com/expediagroup/sdk/rest/util/UrlUtils.kt
+++ b/expediagroup-sdk-rest/src/main/kotlin/com/expediagroup/sdk/rest/util/UrlUtils.kt
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2025 Expedia, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.expediagroup.sdk.rest.util
 
 import com.fasterxml.jackson.core.type.TypeReference
@@ -5,103 +21,98 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import java.net.URLDecoder
 import java.nio.charset.StandardCharsets
 
-/**
- * Parses URL path template parameters and returns a map of template segments to path segments.
- *
- * @param path The actual URL path.
- * @param template The URL template with placeholders.
- * @return A map where the keys are template segments and the values are the corresponding path segments.
- * @throws IllegalArgumentException if either path or template is null.
- */
-fun parseUrlPathTemplateParams(
-    template: String,
-    path: String
-): Map<String, String> =
-    listOf(template, path).map {
-        it.removePrefix("/")
-            .removeSuffix("/")
-            .split("/")
-            .map(String::trim)
-    }.also {
-        val templateSegments = it[0]
-        val pathSegments = it[1]
+object UrlUtils {
+    /**
+     * Parses URL path template parameters and returns a map of template segments to path segments.
+     *
+     * @param path The actual URL path.
+     * @param template The URL template with placeholders.
+     * @return A map where the keys are template segments and the values are the corresponding path segments.
+     * @throws IllegalArgumentException if either path or template is null.
+     */
+    fun parsePathParams(
+        template: String,
+        path: String
+    ): Map<String, String> {
+        val templateSegments = template.trim('/').split('/')
+        val pathSegments = path.trim('/').split('/')
 
         require(templateSegments.size == pathSegments.size) {
-            "Template and path segments must have the same number of segments"
+            "Template and path must contain the same number of segments"
         }
-    }.zipWithNext { templateSegment, pathSegment ->
-        templateSegment.zip(pathSegment)
-    }.flatten().filter { (key, value) ->
-        key != value && key.startsWith("{") && key.endsWith("}")
-    }.associate { (key, value) ->
-        key.removePrefix("{").removeSuffix("}") to value
-    }
 
-/**
- * Parses URL query parameters from a query string and returns a map of parameter names to lists of values.
- *
- * @param query The URL query string.
- * @param destringifyStrategies The strategy to destringify query parameter values (e.g., comma-delimited, space-delimited).
- * @return A map where the keys are parameter names and the values are lists of parameter values.
- */
-fun parseUrlQueryParamsFromQuery(
-    query: String,
-    destringifyStrategies: Map<String, String>
-): Map<String, MutableList<String>> =
-    buildMap {
-        URLDecoder.decode(query, StandardCharsets.UTF_8.name())
-            .trim()
-            .split("&")
-            .filter(String::isNotBlank)
-            .map { it.split("=", limit = 2) }
-            .filter { (key, value) -> key.isNotBlank() && value.isNotBlank() }
-            .map { (key, value) ->
-                key to
-                    if (destringifyStrategies[key] != null && swaggerCollectionFormatDestringifier[destringifyStrategies[key]] != null) {
-                        val destrignfyStrategy = destringifyStrategies[key]
-                        val destringifyFunction = swaggerCollectionFormatDestringifier[destrignfyStrategy]!!
-
-                        destringifyFunction(key, value).value
-                    } else {
-                        value
-                    }
-            }.forEach { (key, value) ->
-                getOrPut(key) {
-                    mutableListOf()
-                }.apply {
-                    when (value) {
-                        is Collection<*> -> {
-                            addAll(value.map { it.toString() })
-                        }
-
-                        else -> {
-                            add(value.toString())
-                        }
-                    }
+        return buildMap {
+            templateSegments
+                .zip(pathSegments)
+                .filter { (templatePart, pathPart) -> templatePart != pathPart }
+                .filter { (templatePart, _) ->
+                    templatePart.startsWith('{') && templatePart.endsWith('}')
                 }
-            }
+                .forEach { (placeholder, value) ->
+                    put(placeholder.trim('{', '}'), value)
+                }
+        }
     }
 
-/**
- * Resolves the type of URL query parameter values and converts them to the specified type.
- *
- * @param values The list of query parameter values as strings.
- * @param objectMapper The Jackson `ObjectMapper` used for type conversion.
- * @param typeRef The Jackson `TypeReference` specifying the target type.
- * @return The converted value of the specified type.
- * @param T The target type to which the query parameter values should be converted.
- */
-fun <T> resolveUrlQueryParamValuesType(
-    values: Collection<String>,
-    objectMapper: ObjectMapper,
-    typeRef: TypeReference<T>
-): T =
-    if (objectMapper.typeFactory.constructType(typeRef).let { it.isContainerType || it.isArrayType }) {
-        objectMapper.convertValue(values, typeRef)
-    } else {
-        require(values.isNotEmpty()) {
-            "Cannot resolve type for empty values"
+    /**
+     * Parses URL query parameters from a query string and returns a map of parameter names to lists of values.
+     *
+     * @param query The URL query string.
+     * @param destringifyStrategies The strategy to destringify query parameter values (e.g., comma-delimited, space-delimited).
+     * @return A map where the keys are parameter names and the values are lists of parameter values.
+     */
+    fun parseQueryParams(
+        query: String,
+        destringifyStrategies: Map<String, String>
+    ): Map<String, MutableList<String>> =
+        buildMap {
+            URLDecoder.decode(query, StandardCharsets.UTF_8.name())
+                .splitToSequence('&')
+                .filter { it.isNotEmpty() }
+                .forEach { token ->
+                    val eq = token.indexOf('=')
+                    if (eq <= 0 || eq == token.lastIndex) return@forEach // malformed
+
+                    val name = token.substring(0, eq)
+                    val rawValue = token.substring(eq + 1)
+
+                    val destringifier =
+                        destringifyStrategies[name]
+                            ?.let {
+                                require(swaggerCollectionFormatDestringifier[it] != null) {
+                                    "Unknown destringify strategy [$it] for key: $name"
+                                }
+
+                                swaggerCollectionFormatDestringifier[it]
+                            }
+
+                    val queryParamValues = destringifier?.invoke(name, rawValue)?.value ?: listOf(rawValue)
+
+                    getOrPut(name, ::mutableListOf).addAll(queryParamValues)
+                }
         }
 
-        objectMapper.convertValue(values.first(), typeRef)
-    }
+    /**
+     * Resolves the type of URL query parameter values and converts them to the specified type.
+     *
+     * @param values The list of query parameter values as strings.
+     * @param objectMapper The Jackson `ObjectMapper` used for type conversion.
+     * @param typeRef The Jackson `TypeReference` specifying the target type.
+     * @return The converted value of the specified type.
+     * @param T The target type to which the query parameter values should be converted.
+     */
+    fun <T> resolveUrlQueryParamValuesType(
+        values: Collection<String>,
+        objectMapper: ObjectMapper,
+        typeRef: TypeReference<T>
+    ): T =
+        if (objectMapper.typeFactory.constructType(typeRef).let { it.isContainerType || it.isArrayType }) {
+            objectMapper.convertValue(values, typeRef)
+        } else {
+            require(values.isNotEmpty()) {
+                "Cannot resolve type for empty values"
+            }
+
+            objectMapper.convertValue(values.first(), typeRef)
+        }
+}

--- a/expediagroup-sdk-rest/src/main/kotlin/com/expediagroup/sdk/rest/util/UrlUtils.kt
+++ b/expediagroup-sdk-rest/src/main/kotlin/com/expediagroup/sdk/rest/util/UrlUtils.kt
@@ -87,21 +87,21 @@ fun parseUrlQueryParamsFromQuery(
  *
  * @param values The list of query parameter values as strings.
  * @param objectMapper The Jackson `ObjectMapper` used for type conversion.
- * @param jacksonTypeRef The Jackson `TypeReference` specifying the target type.
+ * @param typeRef The Jackson `TypeReference` specifying the target type.
  * @return The converted value of the specified type.
  * @param T The target type to which the query parameter values should be converted.
  */
 fun <T> resolveUrlQueryParamValuesType(
     values: Collection<String>,
     objectMapper: ObjectMapper,
-    jacksonTypeRef: TypeReference<T>
+    typeRef: TypeReference<T>
 ): T =
-    if (objectMapper.typeFactory.constructType(jacksonTypeRef).let { it.isContainerType || it.isArrayType }) {
-        objectMapper.convertValue(values, jacksonTypeRef)
+    if (objectMapper.typeFactory.constructType(typeRef).let { it.isContainerType || it.isArrayType }) {
+        objectMapper.convertValue(values, typeRef)
     } else {
         require(values.isNotEmpty()) {
             "Cannot resolve type for empty values"
         }
 
-        objectMapper.convertValue(values.first(), jacksonTypeRef)
+        objectMapper.convertValue(values.first(), typeRef)
     }

--- a/expediagroup-sdk-rest/src/main/kotlin/com/expediagroup/sdk/rest/util/UrlUtils.kt
+++ b/expediagroup-sdk-rest/src/main/kotlin/com/expediagroup/sdk/rest/util/UrlUtils.kt
@@ -1,0 +1,107 @@
+package com.expediagroup.sdk.rest.util
+
+import com.fasterxml.jackson.core.type.TypeReference
+import com.fasterxml.jackson.databind.ObjectMapper
+import java.net.URLDecoder
+import java.nio.charset.StandardCharsets
+
+/**
+ * Parses URL path template parameters and returns a map of template segments to path segments.
+ *
+ * @param path The actual URL path.
+ * @param template The URL template with placeholders.
+ * @return A map where the keys are template segments and the values are the corresponding path segments.
+ * @throws IllegalArgumentException if either path or template is null.
+ */
+fun parseUrlPathTemplateParams(
+    template: String,
+    path: String
+): Map<String, String> =
+    listOf(template, path).map {
+        it.removePrefix("/")
+            .removeSuffix("/")
+            .split("/")
+            .map(String::trim)
+    }.also {
+        val templateSegments = it[0]
+        val pathSegments = it[1]
+
+        require(templateSegments.size == pathSegments.size) {
+            "Template and path segments must have the same number of segments"
+        }
+    }.zipWithNext { templateSegment, pathSegment ->
+        templateSegment.zip(pathSegment)
+    }.flatten().filter { (key, value) ->
+        key != value && key.startsWith("{") && key.endsWith("}")
+    }.associate { (key, value) ->
+        key.removePrefix("{").removeSuffix("}") to value
+    }
+
+/**
+ * Parses URL query parameters from a query string and returns a map of parameter names to lists of values.
+ *
+ * @param query The URL query string.
+ * @param destringifyStrategies The strategy to destringify query parameter values (e.g., comma-delimited, space-delimited).
+ * @return A map where the keys are parameter names and the values are lists of parameter values.
+ */
+fun parseUrlQueryParamsFromQuery(
+    query: String,
+    destringifyStrategies: Map<String, String>
+): Map<String, MutableList<String>> =
+    buildMap {
+        URLDecoder.decode(query, StandardCharsets.UTF_8.name())
+            .trim()
+            .split("&")
+            .filter(String::isNotBlank)
+            .map { it.split("=", limit = 2) }
+            .filter { (key, value) -> key.isNotBlank() && value.isNotBlank() }
+            .map { (key, value) ->
+                key to
+                    if (destringifyStrategies[key] != null && swaggerCollectionFormatDestringifier[destringifyStrategies[key]] != null) {
+                        val destrignfyStrategy = destringifyStrategies[key]
+                        val destringifyFunction = swaggerCollectionFormatDestringifier[destrignfyStrategy]!!
+
+                        destringifyFunction(key, value).value
+                    } else {
+                        value
+                    }
+            }.forEach { (key, value) ->
+                getOrPut(key) {
+                    mutableListOf()
+                }.apply {
+                    when (value) {
+                        is Collection<*> -> {
+                            addAll(value.map { it.toString() })
+                        }
+
+                        else -> {
+                            add(value.toString())
+                        }
+                    }
+                }
+            }
+    }
+
+/**
+ * Resolves the type of URL query parameter values and converts them to the specified type.
+ *
+ * @param values The list of query parameter values as strings.
+ * @param objectMapper The Jackson `ObjectMapper` used for type conversion.
+ * @param jacksonTypeRef The Jackson `TypeReference` specifying the target type.
+ * @return The converted value of the specified type.
+ * @param T The target type to which the query parameter values should be converted.
+ */
+fun <T> resolveUrlQueryParamValuesType(
+    values: Collection<String>,
+    objectMapper: ObjectMapper,
+    jacksonTypeRef: TypeReference<T>
+): T =
+    if (objectMapper.typeFactory.constructType(jacksonTypeRef).let { it.isContainerType || it.isArrayType }) {
+        objectMapper.convertValue(values, jacksonTypeRef)
+    } else {
+        require(values.isNotEmpty()) {
+            "Cannot resolve type for empty values"
+        }
+
+        objectMapper.convertValue(values.first(), jacksonTypeRef)
+    }

--- a/expediagroup-sdk-rest/src/test/kotlin/com/expediagroup/sdk/rest/extension/OperationToRequestExtensionTest.kt
+++ b/expediagroup-sdk-rest/src/test/kotlin/com/expediagroup/sdk/rest/extension/OperationToRequestExtensionTest.kt
@@ -11,7 +11,7 @@ import com.expediagroup.sdk.rest.trait.operation.OperationRequestBodyTrait
 import com.expediagroup.sdk.rest.trait.operation.OperationRequestTrait
 import com.expediagroup.sdk.rest.trait.operation.UrlPathTrait
 import com.expediagroup.sdk.rest.trait.operation.UrlQueryParamsTrait
-import com.expediagroup.sdk.rest.util.UrlQueryParamStringifiers
+import com.expediagroup.sdk.rest.util.UrlQueryParamStringifier
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import okio.Buffer
 import org.junit.jupiter.api.Assertions.assertAll
@@ -250,8 +250,8 @@ class OperationToRequestExtensionTest {
 
                     override fun getUrlQueryParams(): List<UrlQueryParam> =
                         listOf(
-                            UrlQueryParam("key1", listOf("value1"), UrlQueryParamStringifiers.stringifyExplode),
-                            UrlQueryParam("key2", listOf("value2", "value3"), UrlQueryParamStringifiers.stringifyExplode)
+                            UrlQueryParam("key1", listOf("value1"), UrlQueryParamStringifier.explode),
+                            UrlQueryParam("key2", listOf("value2", "value3"), UrlQueryParamStringifier.explode)
                         )
                 }
 
@@ -310,7 +310,7 @@ class OperationToRequestExtensionTest {
 
                     override fun getUrlQueryParams(): List<UrlQueryParam> =
                         listOf(
-                            UrlQueryParam("key2", listOf("value2", "value3"), UrlQueryParamStringifiers.stringifyExplode)
+                            UrlQueryParam("key2", listOf("value2", "value3"), UrlQueryParamStringifier.explode)
                         )
                 }
 
@@ -347,8 +347,8 @@ class OperationToRequestExtensionTest {
 
                     override fun getUrlQueryParams(): List<UrlQueryParam> =
                         listOf(
-                            UrlQueryParam("key1", listOf("value1"), UrlQueryParamStringifiers.stringifyExplode),
-                            UrlQueryParam("key2", listOf("value2", "value3"), UrlQueryParamStringifiers.stringifyExplode)
+                            UrlQueryParam("key1", listOf("value1"), UrlQueryParamStringifier.explode),
+                            UrlQueryParam("key2", listOf("value2", "value3"), UrlQueryParamStringifier.explode)
                         )
                 }
 

--- a/expediagroup-sdk-rest/src/test/kotlin/com/expediagroup/sdk/rest/extension/OperationToRequestExtensionTest.kt
+++ b/expediagroup-sdk-rest/src/test/kotlin/com/expediagroup/sdk/rest/extension/OperationToRequestExtensionTest.kt
@@ -11,7 +11,7 @@ import com.expediagroup.sdk.rest.trait.operation.OperationRequestBodyTrait
 import com.expediagroup.sdk.rest.trait.operation.OperationRequestTrait
 import com.expediagroup.sdk.rest.trait.operation.UrlPathTrait
 import com.expediagroup.sdk.rest.trait.operation.UrlQueryParamsTrait
-import com.expediagroup.sdk.rest.util.stringifyExplode
+import com.expediagroup.sdk.rest.util.UrlQueryParamStringifiers
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import okio.Buffer
 import org.junit.jupiter.api.Assertions.assertAll
@@ -250,8 +250,8 @@ class OperationToRequestExtensionTest {
 
                     override fun getUrlQueryParams(): List<UrlQueryParam> =
                         listOf(
-                            UrlQueryParam("key1", listOf("value1"), stringifyExplode),
-                            UrlQueryParam("key2", listOf("value2", "value3"), stringifyExplode)
+                            UrlQueryParam("key1", listOf("value1"), UrlQueryParamStringifiers.stringifyExplode),
+                            UrlQueryParam("key2", listOf("value2", "value3"), UrlQueryParamStringifiers.stringifyExplode)
                         )
                 }
 
@@ -310,7 +310,7 @@ class OperationToRequestExtensionTest {
 
                     override fun getUrlQueryParams(): List<UrlQueryParam> =
                         listOf(
-                            UrlQueryParam("key2", listOf("value2", "value3"), stringifyExplode)
+                            UrlQueryParam("key2", listOf("value2", "value3"), UrlQueryParamStringifiers.stringifyExplode)
                         )
                 }
 
@@ -347,8 +347,8 @@ class OperationToRequestExtensionTest {
 
                     override fun getUrlQueryParams(): List<UrlQueryParam> =
                         listOf(
-                            UrlQueryParam("key1", listOf("value1"), stringifyExplode),
-                            UrlQueryParam("key2", listOf("value2", "value3"), stringifyExplode)
+                            UrlQueryParam("key1", listOf("value1"), UrlQueryParamStringifiers.stringifyExplode),
+                            UrlQueryParam("key2", listOf("value2", "value3"), UrlQueryParamStringifiers.stringifyExplode)
                         )
                 }
 

--- a/expediagroup-sdk-rest/src/test/kotlin/com/expediagroup/sdk/rest/util/UrlQueryParamUtilsTest.kt
+++ b/expediagroup-sdk-rest/src/test/kotlin/com/expediagroup/sdk/rest/util/UrlQueryParamUtilsTest.kt
@@ -3,7 +3,6 @@ package com.expediagroup.sdk.rest.util
 import com.expediagroup.sdk.rest.model.UrlQueryParam
 import io.mockk.mockk
 import org.junit.jupiter.api.Assertions.assertEquals
-import org.junit.jupiter.api.Assertions.assertInstanceOf
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
@@ -41,53 +40,44 @@ class UrlQueryParamUtilsTest {
         assertEquals(expectedParam, actualParam)
     }
 
-    @Test
-    fun `create instances of UrlQueryParamDestringifiers and UrlQueryParamStringifiers`() {
-        val destringifier = UrlQueryParamDestringifiers()
-        val stringifier = UrlQueryParamStringifiers()
-
-        assertInstanceOf(UrlQueryParamDestringifiers::class.java, destringifier)
-        assertInstanceOf(UrlQueryParamStringifiers::class.java, stringifier)
-    }
-
     @Nested
     inner class StringifiersTest {
         @Test
         fun `stringifyForm should correctly convert UrlQueryParam to form-encoded String`() {
-            val param = UrlQueryParam("myKey", listOf("v1", "v2"), UrlQueryParamStringifiers.stringifyForm)
+            val param = UrlQueryParam("myKey", listOf("v1", "v2"), UrlQueryParamStringifier.form)
             val expectedString = "myKey=v1%2Cv2"
 
-            val actualString = UrlQueryParamStringifiers.stringifyForm(param)
+            val actualString = UrlQueryParamStringifier.form(param)
 
             assertEquals(expectedString, actualString)
         }
 
         @Test
         fun `stringifyExplode should correctly convert UrlQueryParam to exploded form-encoded String`() {
-            val param = UrlQueryParam("myKey", listOf("v1", "v2"), UrlQueryParamStringifiers.stringifyExplode)
+            val param = UrlQueryParam("myKey", listOf("v1", "v2"), UrlQueryParamStringifier.explode)
             val expectedString = "myKey=v1&myKey=v2"
 
-            val actualString = UrlQueryParamStringifiers.stringifyExplode(param)
+            val actualString = UrlQueryParamStringifier.explode(param)
 
             assertEquals(expectedString, actualString)
         }
 
         @Test
         fun `stringifySpaceDelimited should correctly convert UrlQueryParam to space-delimited String`() {
-            val param = UrlQueryParam("myKey", listOf("v1", "v2"), UrlQueryParamStringifiers.stringifySpaceDelimited)
+            val param = UrlQueryParam("myKey", listOf("v1", "v2"), UrlQueryParamStringifier.spaceDelimited)
             val expectedString = "myKey=v1+v2"
 
-            val actualString = UrlQueryParamStringifiers.stringifySpaceDelimited(param)
+            val actualString = UrlQueryParamStringifier.spaceDelimited(param)
 
             assertEquals(expectedString, actualString)
         }
 
         @Test
         fun `stringifyPipeDelimited should correctly convert UrlQueryParam to pipe-delimited String`() {
-            val param = UrlQueryParam("myKey", listOf("v1", "v2"), UrlQueryParamStringifiers.stringifyPipeDelimited)
+            val param = UrlQueryParam("myKey", listOf("v1", "v2"), UrlQueryParamStringifier.pipeDelimited)
             val expectedString = "myKey=v1%7Cv2"
 
-            val actualString = UrlQueryParamStringifiers.stringifyPipeDelimited(param)
+            val actualString = UrlQueryParamStringifier.pipeDelimited(param)
 
             assertEquals(expectedString, actualString)
         }
@@ -95,10 +85,10 @@ class UrlQueryParamUtilsTest {
         @Test
         fun `swaggerCollectionFormatStringifier should return correct stringify method`() {
             mapOf(
-                "csv" to UrlQueryParamStringifiers.stringifyForm,
-                "pipes" to UrlQueryParamStringifiers.stringifyPipeDelimited,
-                "ssv" to UrlQueryParamStringifiers.stringifySpaceDelimited,
-                "multi" to UrlQueryParamStringifiers.stringifyExplode
+                "csv" to UrlQueryParamStringifier.form,
+                "pipes" to UrlQueryParamStringifier.pipeDelimited,
+                "ssv" to UrlQueryParamStringifier.spaceDelimited,
+                "multi" to UrlQueryParamStringifier.explode
             ).forEach { (format, expected) ->
                 assertEquals(swaggerCollectionFormatStringifier.get(format), expected)
             }
@@ -114,8 +104,8 @@ class UrlQueryParamUtilsTest {
             val queryParamValue = "v1,v2"
 
             // When
-            val actualParam = UrlQueryParamDestringifiers.destringifyForm(queryParamName, queryParamValue)
-            val expectedParam = UrlQueryParam("myKey", listOf("v1", "v2"), UrlQueryParamStringifiers.stringifyForm)
+            val actualParam = UrlQueryParamDestringifiers.form(queryParamName, queryParamValue)
+            val expectedParam = UrlQueryParam("myKey", listOf("v1", "v2"), UrlQueryParamStringifier.form)
 
             // Then
             assertEquals(expectedParam, actualParam)
@@ -128,8 +118,8 @@ class UrlQueryParamUtilsTest {
             val queryParamValue = "v1&v2"
 
             // When
-            val actualParam = UrlQueryParamDestringifiers.destringifyExplode(queryParamName, queryParamValue)
-            val expectedParam = UrlQueryParam("myKey", listOf("v1", "v2"), UrlQueryParamStringifiers.stringifyExplode)
+            val actualParam = UrlQueryParamDestringifiers.explode(queryParamName, queryParamValue)
+            val expectedParam = UrlQueryParam("myKey", listOf("v1", "v2"), UrlQueryParamStringifier.explode)
 
             // Then
             assertEquals(expectedParam, actualParam)
@@ -142,8 +132,8 @@ class UrlQueryParamUtilsTest {
             val queryParamValue = "v1 v2"
 
             // When
-            val actualParam = UrlQueryParamDestringifiers.destringifySpaceDelimited(queryParamName, queryParamValue)
-            val expectedParam = UrlQueryParam("myKey", listOf("v1", "v2"), UrlQueryParamStringifiers.stringifySpaceDelimited)
+            val actualParam = UrlQueryParamDestringifiers.spaceDelimited(queryParamName, queryParamValue)
+            val expectedParam = UrlQueryParam("myKey", listOf("v1", "v2"), UrlQueryParamStringifier.spaceDelimited)
 
             // Then
             assertEquals(expectedParam, actualParam)
@@ -156,8 +146,8 @@ class UrlQueryParamUtilsTest {
             val queryParamValue = "v1|v2"
 
             // When
-            val actualParam = UrlQueryParamDestringifiers.destringifyPipeDelimited(queryParamName, queryParamValue)
-            val expectedParam = UrlQueryParam("myKey", listOf("v1", "v2"), UrlQueryParamStringifiers.stringifyPipeDelimited)
+            val actualParam = UrlQueryParamDestringifiers.pipeDelimited(queryParamName, queryParamValue)
+            val expectedParam = UrlQueryParam("myKey", listOf("v1", "v2"), UrlQueryParamStringifier.pipeDelimited)
 
             // Then
             assertEquals(expectedParam, actualParam)
@@ -170,10 +160,10 @@ class UrlQueryParamUtilsTest {
             val queryParamValue = "v1"
 
             // When
-            val pipeDelimitedActualParam = UrlQueryParamDestringifiers.destringifyPipeDelimited(queryParamName, queryParamValue)
-            val spaceDelimitedActualParam = UrlQueryParamDestringifiers.destringifySpaceDelimited(queryParamName, queryParamValue)
-            val explodeActualParam = UrlQueryParamDestringifiers.destringifyExplode(queryParamName, queryParamValue)
-            val formActualParam = UrlQueryParamDestringifiers.destringifyForm(queryParamName, queryParamValue)
+            val pipeDelimitedActualParam = UrlQueryParamDestringifiers.pipeDelimited(queryParamName, queryParamValue)
+            val spaceDelimitedActualParam = UrlQueryParamDestringifiers.spaceDelimited(queryParamName, queryParamValue)
+            val explodeActualParam = UrlQueryParamDestringifiers.explode(queryParamName, queryParamValue)
+            val formActualParam = UrlQueryParamDestringifiers.form(queryParamName, queryParamValue)
 
             val expectedValue = listOf("v1")
 

--- a/expediagroup-sdk-rest/src/test/kotlin/com/expediagroup/sdk/rest/util/UrlUtilsTest.kt
+++ b/expediagroup-sdk-rest/src/test/kotlin/com/expediagroup/sdk/rest/util/UrlUtilsTest.kt
@@ -1,0 +1,380 @@
+package com.expediagroup.sdk.rest.util
+
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.fasterxml.jackson.module.kotlin.jacksonTypeRef
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ValueSource
+
+class UrlUtilsTest {
+    @Nested
+    inner class ParseUrlPathTemplateParamsTest {
+        @Test
+        fun `parses path template parameters correctly`() {
+            // Given
+            val template = "/api/v1/users/{userId}/posts/{postId}"
+            val path = "/api/v1/users/123/posts/456"
+
+            // When
+            val result =
+                parseUrlPathTemplateParams(
+                    template = template,
+                    path = path
+                )
+
+            // Then
+            val expected =
+                mapOf(
+                    "userId" to "123",
+                    "postId" to "456"
+                )
+            assertEquals(expected, result)
+        }
+
+        @Test
+        fun `throws illegalArgumentException when template and path do not match`() {
+            // Given
+            val template = "/api/v1/users"
+            val path = "/api/v1/users/123/posts/456"
+
+            // When
+            val exception =
+                assertThrows<IllegalArgumentException> {
+                    parseUrlPathTemplateParams(
+                        template = template,
+                        path = path
+                    )
+                }
+
+            // Then
+            val expectedExceptionMessage =
+                "Template and path segments must have the same number of segments"
+
+            assertEquals(expectedExceptionMessage, exception.message)
+        }
+
+        @Test
+        fun `returns empty map when template and path are identical`() {
+            // Given
+            val template = "/api/v1/users/123/posts/456"
+            val path = "/api/v1/users/123/posts/456"
+
+            // When
+            val result =
+                parseUrlPathTemplateParams(
+                    template = template,
+                    path = path
+                )
+
+            // Then
+            assertEquals(emptyMap<String, String>(), result)
+        }
+
+        @ParameterizedTest
+        @ValueSource(
+            strings = [
+                "{id",
+                "id}",
+                "i{d}",
+                "{i}d"
+            ]
+        )
+        fun `does not parse param when param format is invalid`(paramTemplate: String) {
+            // Given
+            val template = "/api/v1/users/$paramTemplate"
+            val path = "/api/v1/users/123"
+
+            // When
+            val result =
+                parseUrlPathTemplateParams(
+                    template = template,
+                    path = path
+                )
+
+            // Then
+            assertEquals(emptyMap<String, String>(), result)
+        }
+
+        @Test
+        fun `returns empty map when template and path are empty`() {
+            // Given
+            val template = ""
+            val path = ""
+
+            // When
+            val result =
+                parseUrlPathTemplateParams(
+                    template = template,
+                    path = path
+                )
+
+            // Then
+            assertEquals(emptyMap<String, String>(), result)
+        }
+    }
+
+    @Nested
+    inner class ParseUrlQueryParamsFromQueryTest {
+        @Test
+        fun `parses query string with pipe-delimited values using pipe strategy`() {
+            val query = "key=value1|value2|value3"
+            val destringifyStrategies = mapOf("key" to "pipes")
+
+            val result = parseUrlQueryParamsFromQuery(query, destringifyStrategies)
+
+            val expected =
+                mapOf(
+                    "key" to mutableListOf("value1", "value2", "value3")
+                )
+            assertEquals(expected, result)
+        }
+
+        @Test
+        fun `parses query string with comma-separated values using csv strategy`() {
+            val query = "key=value1,value2,value3"
+            val destringifyStrategies = mapOf("key" to "csv")
+
+            val result = parseUrlQueryParamsFromQuery(query, destringifyStrategies)
+
+            val expected =
+                mapOf(
+                    "key" to mutableListOf("value1", "value2", "value3")
+                )
+            assertEquals(expected, result)
+        }
+
+        @Test
+        fun `parses query string with single key-value pair correctly`() {
+            val query = "key=value"
+            val destringifyStrategies = emptyMap<String, String>()
+
+            val result = parseUrlQueryParamsFromQuery(query, destringifyStrategies)
+
+            val expected =
+                mapOf(
+                    "key" to mutableListOf("value")
+                )
+            assertEquals(expected, result)
+        }
+
+        @Test
+        fun `parses query string with multiple key-value pairs correctly`() {
+            val query = "key1=value1&key2=value2"
+            val destringifyStrategies = emptyMap<String, String>()
+
+            val result = parseUrlQueryParamsFromQuery(query, destringifyStrategies)
+
+            val expected =
+                mapOf(
+                    "key1" to mutableListOf("value1"),
+                    "key2" to mutableListOf("value2")
+                )
+            assertEquals(expected, result)
+        }
+
+        @Test
+        fun `parses query string with space-delimited values using space strategy`() {
+            val query = "key=value1%20value2%20value3"
+            val destringifyStrategies = mapOf("key" to "ssv")
+
+            val result = parseUrlQueryParamsFromQuery(query, destringifyStrategies)
+
+            val expected =
+                mapOf(
+                    "key" to mutableListOf("value1", "value2", "value3")
+                )
+            assertEquals(expected, result)
+        }
+
+        @Test
+        fun `parses query string with special characters correctly`() {
+            val query = "key1=value%201&key2=value%2C2"
+            val destringifyStrategies = emptyMap<String, String>()
+
+            val result = parseUrlQueryParamsFromQuery(query, destringifyStrategies)
+
+            val expected =
+                mapOf(
+                    "key1" to mutableListOf("value 1"),
+                    "key2" to mutableListOf("value,2")
+                )
+            assertEquals(expected, result)
+        }
+
+        @Test
+        fun `ignores empty query string and returns empty map`() {
+            val query = ""
+            val destringifyStrategies = emptyMap<String, String>()
+
+            val result = parseUrlQueryParamsFromQuery(query, destringifyStrategies)
+
+            assertEquals(emptyMap<String, MutableList<String>>(), result)
+        }
+
+        @Test
+        fun `ignores invalid query parameters with missing keys or values`() {
+            val query = "key1=value1&=value2&key3="
+            val destringifyStrategies = emptyMap<String, String>()
+
+            val result = parseUrlQueryParamsFromQuery(query, destringifyStrategies)
+
+            val expected =
+                mapOf(
+                    "key1" to mutableListOf("value1")
+                )
+            assertEquals(expected, result)
+        }
+
+        @Test
+        fun `parses query parameters correctly with multiple destringify strategies`() {
+            // Given
+            val query = "param1=value1&param1=value2&param2=value2&csvarray=2,3,4&pipesarray=5|6|7"
+            val destringifyStrategies =
+                mapOf(
+                    "csvarray" to "csv",
+                    "pipesarray" to "pipes"
+                )
+
+            // When
+            val result =
+                parseUrlQueryParamsFromQuery(
+                    query = query,
+                    destringifyStrategies = destringifyStrategies
+                )
+
+            // Then
+            val expected =
+                mapOf(
+                    "param1" to mutableListOf("value1", "value2"),
+                    "param2" to mutableListOf("value2"),
+                    "csvarray" to mutableListOf("2", "3", "4"),
+                    "pipesarray" to mutableListOf("5", "6", "7")
+                )
+
+            assertEquals(expected, result)
+        }
+
+        @Test
+        fun `does not destringify query parameters without a strategy`() {
+            // Given
+            val query = "param1=value1&param2=value2,value3"
+            val destringifyStrategies = emptyMap<String, String>()
+
+            // When
+            val result = parseUrlQueryParamsFromQuery(query, destringifyStrategies)
+
+            // Then
+            val expected =
+                mapOf(
+                    "param1" to mutableListOf("value1"),
+                    "param2" to mutableListOf("value2,value3")
+                )
+            assertEquals(expected, result)
+        }
+
+        @Test
+        fun `does not destringify query parameters with unknown strategy`() {
+            // Given
+            val query = "param1=value1&param2=value2,value3"
+            val destringifyStrategies = mapOf("param2" to "random")
+
+            // When
+            val result = parseUrlQueryParamsFromQuery(query, destringifyStrategies)
+
+            // Then
+            val expected =
+                mapOf(
+                    "param1" to mutableListOf("value1"),
+                    "param2" to mutableListOf("value2,value3")
+                )
+            assertEquals(expected, result)
+        }
+    }
+
+    @Nested
+    inner class ResolveUrlQueryParamValuesTypeTest {
+        private val objectMapper = jacksonObjectMapper()
+
+        @Test
+        fun `resolves single value to specified type`() {
+            val values = listOf("123")
+            val jacksonTypeRef = jacksonTypeRef<Int>()
+
+            val result = resolveUrlQueryParamValuesType(values, objectMapper, jacksonTypeRef)
+            val expected = 123
+
+            assertEquals(expected, result)
+        }
+
+        @Test
+        fun `resolves multiple values to list of specified type`() {
+            val values = listOf("1", "2", "3")
+            val jacksonTypeRef = jacksonTypeRef<List<Int>>()
+
+            val result = resolveUrlQueryParamValuesType(values, objectMapper, jacksonTypeRef)
+            val expected = listOf(1, 2, 3)
+
+            assertEquals(expected, result)
+        }
+
+        @Test
+        fun `resolves single value to string when type is string`() {
+            val values = listOf("testValue")
+            val jacksonTypeRef = jacksonTypeRef<String>()
+
+            val result = resolveUrlQueryParamValuesType(values, objectMapper, jacksonTypeRef)
+            val expected = "testValue"
+
+            assertEquals(expected, result)
+        }
+
+        @Test
+        fun `returns empty list when values list is empty and type ref is a list`() {
+            val values = emptyList<String>()
+            val jacksonTypeRef = jacksonTypeRef<List<Int>>()
+
+            val result = resolveUrlQueryParamValuesType(values, objectMapper, jacksonTypeRef)
+            val expected = emptyList<Int>()
+
+            assertEquals(expected, result)
+        }
+
+        @Test
+        fun `throws IllegalArgumentException when unable to convert values to specified type`() {
+            val values = listOf("invalidValue")
+            val jacksonTypeRef = jacksonTypeRef<Int>()
+
+            assertThrows<IllegalArgumentException> {
+                resolveUrlQueryParamValuesType(values, objectMapper, jacksonTypeRef)
+            }
+        }
+
+        @Test
+        fun `throws IllegalArgumentException when type ref is not container and values list is empty`() {
+            // Given
+            val values = emptyList<String>()
+
+            val jacksonTypeRef1 = jacksonTypeRef<Int>()
+            val jacksonTypeRef2 = jacksonTypeRef<String>()
+
+            // When
+            val exception1 =
+                assertThrows<IllegalArgumentException> {
+                    resolveUrlQueryParamValuesType(values, objectMapper, jacksonTypeRef1)
+                }
+            val exception2 =
+                assertThrows<IllegalArgumentException> {
+                    resolveUrlQueryParamValuesType(values, objectMapper, jacksonTypeRef2)
+                }
+
+            // Then
+            val expectedExceptionMessage = "Cannot resolve type for empty values"
+
+            assertEquals(expectedExceptionMessage, exception1.message)
+            assertEquals(expectedExceptionMessage, exception2.message)
+        }
+    }
+}

--- a/expediagroup-sdk-rest/src/test/kotlin/com/expediagroup/sdk/rest/util/UrlUtilsTest.kt
+++ b/expediagroup-sdk-rest/src/test/kotlin/com/expediagroup/sdk/rest/util/UrlUtilsTest.kt
@@ -2,6 +2,7 @@ package com.expediagroup.sdk.rest.util
 
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.fasterxml.jackson.module.kotlin.jacksonTypeRef
+import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -11,7 +12,7 @@ import org.junit.jupiter.params.provider.ValueSource
 
 class UrlUtilsTest {
     @Nested
-    inner class ParseUrlPathTemplateParamsTest {
+    inner class ParsePathParamsTest {
         @Test
         fun `parses path template parameters correctly`() {
             // Given
@@ -20,7 +21,7 @@ class UrlUtilsTest {
 
             // When
             val result =
-                parseUrlPathTemplateParams(
+                UrlUtils.parsePathParams(
                     template = template,
                     path = path
                 )
@@ -43,15 +44,14 @@ class UrlUtilsTest {
             // When
             val exception =
                 assertThrows<IllegalArgumentException> {
-                    parseUrlPathTemplateParams(
+                    UrlUtils.parsePathParams(
                         template = template,
                         path = path
                     )
                 }
 
             // Then
-            val expectedExceptionMessage =
-                "Template and path segments must have the same number of segments"
+            val expectedExceptionMessage = "Template and path must contain the same number of segments"
 
             assertEquals(expectedExceptionMessage, exception.message)
         }
@@ -64,7 +64,7 @@ class UrlUtilsTest {
 
             // When
             val result =
-                parseUrlPathTemplateParams(
+                UrlUtils.parsePathParams(
                     template = template,
                     path = path
                 )
@@ -89,7 +89,7 @@ class UrlUtilsTest {
 
             // When
             val result =
-                parseUrlPathTemplateParams(
+                UrlUtils.parsePathParams(
                     template = template,
                     path = path
                 )
@@ -106,7 +106,7 @@ class UrlUtilsTest {
 
             // When
             val result =
-                parseUrlPathTemplateParams(
+                UrlUtils.parsePathParams(
                     template = template,
                     path = path
                 )
@@ -117,18 +117,24 @@ class UrlUtilsTest {
     }
 
     @Nested
-    inner class ParseUrlQueryParamsFromQueryTest {
+    inner class ParseQueryParamsTest {
         @Test
         fun `parses query string with pipe-delimited values using pipe strategy`() {
-            val query = "key=value1|value2|value3"
-            val destringifyStrategies = mapOf("key" to "pipes")
+            val query = "key=value1|value2|value3&key2=value1,value2"
+            val destringifyStrategies =
+                mapOf(
+                    "key" to "pipes",
+                    "key2" to "csv"
+                )
 
-            val result = parseUrlQueryParamsFromQuery(query, destringifyStrategies)
+            val result = UrlUtils.parseQueryParams(query, destringifyStrategies)
 
             val expected =
                 mapOf(
-                    "key" to mutableListOf("value1", "value2", "value3")
+                    "key" to mutableListOf("value1", "value2", "value3"),
+                    "key2" to mutableListOf("value1", "value2")
                 )
+
             assertEquals(expected, result)
         }
 
@@ -137,7 +143,7 @@ class UrlUtilsTest {
             val query = "key=value1,value2,value3"
             val destringifyStrategies = mapOf("key" to "csv")
 
-            val result = parseUrlQueryParamsFromQuery(query, destringifyStrategies)
+            val result = UrlUtils.parseQueryParams(query, destringifyStrategies)
 
             val expected =
                 mapOf(
@@ -151,7 +157,7 @@ class UrlUtilsTest {
             val query = "key=value"
             val destringifyStrategies = emptyMap<String, String>()
 
-            val result = parseUrlQueryParamsFromQuery(query, destringifyStrategies)
+            val result = UrlUtils.parseQueryParams(query, destringifyStrategies)
 
             val expected =
                 mapOf(
@@ -165,7 +171,7 @@ class UrlUtilsTest {
             val query = "key1=value1&key2=value2"
             val destringifyStrategies = emptyMap<String, String>()
 
-            val result = parseUrlQueryParamsFromQuery(query, destringifyStrategies)
+            val result = UrlUtils.parseQueryParams(query, destringifyStrategies)
 
             val expected =
                 mapOf(
@@ -180,7 +186,7 @@ class UrlUtilsTest {
             val query = "key=value1%20value2%20value3"
             val destringifyStrategies = mapOf("key" to "ssv")
 
-            val result = parseUrlQueryParamsFromQuery(query, destringifyStrategies)
+            val result = UrlUtils.parseQueryParams(query, destringifyStrategies)
 
             val expected =
                 mapOf(
@@ -194,7 +200,7 @@ class UrlUtilsTest {
             val query = "key1=value%201&key2=value%2C2"
             val destringifyStrategies = emptyMap<String, String>()
 
-            val result = parseUrlQueryParamsFromQuery(query, destringifyStrategies)
+            val result = UrlUtils.parseQueryParams(query, destringifyStrategies)
 
             val expected =
                 mapOf(
@@ -209,7 +215,7 @@ class UrlUtilsTest {
             val query = ""
             val destringifyStrategies = emptyMap<String, String>()
 
-            val result = parseUrlQueryParamsFromQuery(query, destringifyStrategies)
+            val result = UrlUtils.parseQueryParams(query, destringifyStrategies)
 
             assertEquals(emptyMap<String, MutableList<String>>(), result)
         }
@@ -219,7 +225,7 @@ class UrlUtilsTest {
             val query = "key1=value1&=value2&key3="
             val destringifyStrategies = emptyMap<String, String>()
 
-            val result = parseUrlQueryParamsFromQuery(query, destringifyStrategies)
+            val result = UrlUtils.parseQueryParams(query, destringifyStrategies)
 
             val expected =
                 mapOf(
@@ -240,7 +246,7 @@ class UrlUtilsTest {
 
             // When
             val result =
-                parseUrlQueryParamsFromQuery(
+                UrlUtils.parseQueryParams(
                     query = query,
                     destringifyStrategies = destringifyStrategies
                 )
@@ -264,7 +270,7 @@ class UrlUtilsTest {
             val destringifyStrategies = emptyMap<String, String>()
 
             // When
-            val result = parseUrlQueryParamsFromQuery(query, destringifyStrategies)
+            val result = UrlUtils.parseQueryParams(query, destringifyStrategies)
 
             // Then
             val expected =
@@ -276,21 +282,20 @@ class UrlUtilsTest {
         }
 
         @Test
-        fun `does not destringify query parameters with unknown strategy`() {
+        fun `throws IllegalArgumentException on unknown destringify strategy`() {
             // Given
             val query = "param1=value1&param2=value2,value3"
             val destringifyStrategies = mapOf("param2" to "random")
 
             // When
-            val result = parseUrlQueryParamsFromQuery(query, destringifyStrategies)
+            val exception =
+                Assertions.assertThrows(IllegalArgumentException::class.java) {
+                    UrlUtils.parseQueryParams(query, destringifyStrategies)
+                }
 
             // Then
-            val expected =
-                mapOf(
-                    "param1" to mutableListOf("value1"),
-                    "param2" to mutableListOf("value2,value3")
-                )
-            assertEquals(expected, result)
+            val expectedMessage = "Unknown destringify strategy [random] for key: param2"
+            assertEquals(expectedMessage, exception.message)
         }
     }
 
@@ -303,7 +308,7 @@ class UrlUtilsTest {
             val values = listOf("123")
             val jacksonTypeRef = jacksonTypeRef<Int>()
 
-            val result = resolveUrlQueryParamValuesType(values, objectMapper, jacksonTypeRef)
+            val result = UrlUtils.resolveUrlQueryParamValuesType(values, objectMapper, jacksonTypeRef)
             val expected = 123
 
             assertEquals(expected, result)
@@ -314,7 +319,7 @@ class UrlUtilsTest {
             val values = listOf("1", "2", "3")
             val jacksonTypeRef = jacksonTypeRef<List<Int>>()
 
-            val result = resolveUrlQueryParamValuesType(values, objectMapper, jacksonTypeRef)
+            val result = UrlUtils.resolveUrlQueryParamValuesType(values, objectMapper, jacksonTypeRef)
             val expected = listOf(1, 2, 3)
 
             assertEquals(expected, result)
@@ -325,7 +330,7 @@ class UrlUtilsTest {
             val values = listOf("testValue")
             val jacksonTypeRef = jacksonTypeRef<String>()
 
-            val result = resolveUrlQueryParamValuesType(values, objectMapper, jacksonTypeRef)
+            val result = UrlUtils.resolveUrlQueryParamValuesType(values, objectMapper, jacksonTypeRef)
             val expected = "testValue"
 
             assertEquals(expected, result)
@@ -336,7 +341,7 @@ class UrlUtilsTest {
             val values = emptyList<String>()
             val jacksonTypeRef = jacksonTypeRef<List<Int>>()
 
-            val result = resolveUrlQueryParamValuesType(values, objectMapper, jacksonTypeRef)
+            val result = UrlUtils.resolveUrlQueryParamValuesType(values, objectMapper, jacksonTypeRef)
             val expected = emptyList<Int>()
 
             assertEquals(expected, result)
@@ -348,7 +353,7 @@ class UrlUtilsTest {
             val jacksonTypeRef = jacksonTypeRef<Int>()
 
             assertThrows<IllegalArgumentException> {
-                resolveUrlQueryParamValuesType(values, objectMapper, jacksonTypeRef)
+                UrlUtils.resolveUrlQueryParamValuesType(values, objectMapper, jacksonTypeRef)
             }
         }
 
@@ -363,11 +368,11 @@ class UrlUtilsTest {
             // When
             val exception1 =
                 assertThrows<IllegalArgumentException> {
-                    resolveUrlQueryParamValuesType(values, objectMapper, jacksonTypeRef1)
+                    UrlUtils.resolveUrlQueryParamValuesType(values, objectMapper, jacksonTypeRef1)
                 }
             val exception2 =
                 assertThrows<IllegalArgumentException> {
-                    resolveUrlQueryParamValuesType(values, objectMapper, jacksonTypeRef2)
+                    UrlUtils.resolveUrlQueryParamValuesType(values, objectMapper, jacksonTypeRef2)
                 }
 
             // Then


### PR DESCRIPTION
# Situation
The current SDK REST module lacks proper utilities for handling and parsing URL paths and query parameters from [HATEOAS](https://en.wikipedia.org/wiki/HATEOAS) links. This limitation prevents implementing robust link-following capabilities, a core principle of REST architectural style. Currently, when receiving links in API responses, we cannot efficiently extract path parameters, parse query parameters with different formatting strategies (CSV, SSV, pipes), or convert string values to appropriate data types. This makes it difficult to follow links and perform subsequent API operations.

# Task
- Develop a comprehensive URL path template parsing utility capable of extracting named parameters from path templates
- Create a query string parser supporting multiple collection format strategies (CSV, SSV, pipes, multi)
- Implement type conversion utilities with proper error handling for string-to-type conversion
- Refactor existing URL query parameter utilities for better organization and maintainability
- Create code generation templates for link builder methods to automate implementation in generated clients

# Action
1. Created new `UrlUtils.kt` with three core utilities:
   - `parseUrlPathTemplateParams`: Uses a segment-by-segment comparison algorithm to match template paths against actual paths, extracting parameter values from segments enclosed in `{` and `}` brackets
   - `parseUrlQueryParamsFromQuery`: Parses URL-encoded query strings, applying configurable destringification strategies for different collection formats
   - `resolveUrlQueryParamValuesType`: Applies type conversion using Jackson's type system, handling both single values and collections

2. Refactored `UrlQueryParamUtils.kt` with a cleaner design:
   - Created `UrlQueryParamStringifiers` class with companion object for stateless stringifier functions
   - Implemented `DestringifyQueryParam` functional interface for the reverse operation
   - Added `UrlQueryParamDestringifiers` with implementations for CSV, SSV, pipes formats
   - Created lookup map `swaggerCollectionFormatDestringifier` for format-based strategy selection
   - Ensured backward compatibility with existing code

3. Implemented `link_builder_method.mustache` template with:
   - Intelligent URL decomposition into path and query components
   - Dynamic path parameter extraction and type conversion
   - Query parameter extraction with format-specific destringification
   - Null safety and empty value handling throughout

4. Renamed parameter in `resolveUrlQueryParamValuesType` from `jacksonTypeRef` to `typeRef` for better naming consistency across the codebase

# Testing
- Implemented 380+ lines of comprehensive tests in `UrlUtilsTest.kt` with nested test classes:
  - `ParseUrlPathTemplateParamsTest`: Tests path parsing with various template patterns, including malformed templates and edge cases
  - `ParseUrlQueryParamsFromQueryTest`: Tests query parsing with different collection formats, encoding issues, and empty values
  - `ResolveUrlQueryParamValuesTypeTest`: Tests type conversion for primitives, collections, and handling of conversion failures

- Added additional tests for refactored `UrlQueryParamUtils`:
  - Verified all destringifiers (form, explode, space-delimited, pipe-delimited)
  - Tested format strategies with single values vs. collections
  - Confirmed backward compatibility with existing code

- Tested integration with mustache template rendering to ensure generated code works correctly

# Results
- Successfully implemented URL path template parsing with robustness against malformed inputs
- Created flexible query parameter parsing with support for all OpenAPI collection formats
- Implemented type-safe conversion between string values and target types using Jackson's type system
- Organized code with clear separation of concerns between stringification, destringification, and type conversion
- Ensured seamless integration with code generation templates to generate link builder methods

These utilities now enable HATEOAS compliance in the SDK by allowing clients to follow links received in responses. The implementation is type-safe, well-tested, and aligned with REST principles.