### PR TITLE
fix: resolve template bugs

### DIFF
--- a/expediagroup-sdk-openapi-plugin/src/main/resources/templates/operation_params.mustache
+++ b/expediagroup-sdk-openapi-plugin/src/main/resources/templates/operation_params.mustache
@@ -43,10 +43,6 @@ package com.expediagroup.sdk.{{namespace}}.operations
                 {{>operations/params/get_query_params}}
 
                 {{>operations/params/get_path_params}}
-
-                {{#link}}
-                    {{>operations/params/link_builder_method}}
-                {{/link}}
                 }
             {{/hasNonBodyParams}}
         {{/processOperation}}

--- a/expediagroup-sdk-openapi-plugin/src/main/resources/templates/operations/params/builder.mustache
+++ b/expediagroup-sdk-openapi-plugin/src/main/resources/templates/operations/params/builder.mustache
@@ -27,6 +27,10 @@ class Builder(
         return params
     }
 
+    {{#link}}
+        {{>operations/params/link_builder_method}}
+    {{/link}}
+
 }
 
 fun toBuilder() = Builder(

--- a/expediagroup-sdk-openapi-plugin/src/main/resources/templates/operations/params/get_query_params.mustache
+++ b/expediagroup-sdk-openapi-plugin/src/main/resources/templates/operations/params/get_query_params.mustache
@@ -15,7 +15,7 @@
         add(UrlQueryParam(
         key = key,
         value = value,
-        stringify = swaggerCollectionFormatStringifier.getOrDefault("{{collectionFormat}}", stringifyExplode)
+        stringify = swaggerCollectionFormatStringifier.getOrDefault("{{collectionFormat}}", explode)
         ))
         }
     {{/queryParams}}

--- a/expediagroup-sdk-openapi-plugin/src/main/resources/templates/operations/params/link_builder_method.mustache
+++ b/expediagroup-sdk-openapi-plugin/src/main/resources/templates/operations/params/link_builder_method.mustache
@@ -11,9 +11,12 @@ fun withLink(link: {{#linkType}}{{{.}}}{{/linkType}}) = apply {
         )
 
         {{#pathParams}}
-            if (pathParams.containsKey("{{{baseName}}}") {
-                pathParams["{{{baseName}}}"].takeIf { it.isNotBlank() }?.let {
-                    this.{{{paramName}}} = {{{jacksonObjectMapper}}}.convertValue(it, jacksonTypeRef<{{>partials/datatype}}>())
+            if (pathParams.containsKey("{{{baseName}}}")) {
+                pathParams["{{{baseName}}}"].takeIf { !it.isNullOrEmpty() }?.let {
+                    this.{{{paramName}}} = {{{jacksonObjectMapper}}}.convertValue(
+                        it,
+                        com.fasterxml.jackson.module.kotlin.jacksonTypeRef<{{>partials/datatype}}>()
+                    )
                 }
             }
         {{/pathParams}}
@@ -31,8 +34,8 @@ fun withLink(link: {{#linkType}}{{{.}}}{{/linkType}}) = apply {
         )
 
     {{#queryParams}}
-        if (queryParams.containsKey("{{{baseName}}}") {
-            queryParams["{{{baseName}}}"]?.takeIf { it.isNotEmpty() }?.let { values: List<String> ->
+        if (queryParams.containsKey("{{{baseName}}}")) {
+            queryParams["{{{baseName}}}"]?.takeIf { !it.isNullOrEmpty() }?.let { values: List<String> ->
                 this.{{{paramName}}} = com.expediagroup.sdk.rest.util.UrlUtils.resolveUrlQueryParamValuesType<{{>partials/datatype}}>(
                     values = values,
                     objectMapper = {{{jacksonObjectMapper}}},

--- a/expediagroup-sdk-openapi-plugin/src/main/resources/templates/traits/imports.mustache
+++ b/expediagroup-sdk-openapi-plugin/src/main/resources/templates/traits/imports.mustache
@@ -15,7 +15,7 @@
             import com.expediagroup.sdk.rest.trait.operation.UrlQueryParamsTrait
             import com.expediagroup.sdk.rest.model.UrlQueryParam
             import com.expediagroup.sdk.rest.util.swaggerCollectionFormatStringifier
-            import com.expediagroup.sdk.rest.util.stringifyExplode
+            import com.expediagroup.sdk.rest.util.UrlQueryParamStringifier.explode
         {{/hasQueryParams}}
         {{#hasHeaderParams}}
             import com.expediagroup.sdk.rest.trait.operation.HeadersTrait


### PR DESCRIPTION
# Situation
The changes in this PR address multiple bugs and inconsistencies in the `operation_params.mustache`, `builder.mustache`, `get_query_params.mustache`, `link_builder_method.mustache`, and `imports.mustache` templates. These issues were causing incorrect behavior during the generation of operation parameters, improper handling of query and path parameters, and outdated or missing imports.

# Task
The objective of this PR is to resolve the identified bugs by updating the templates to improve parameter handling, fix logical errors in conditions, and ensure the correct usage of imports and utilities. This will enhance the functionality and reliability of the generated code.

# Action
- Removed unnecessary `link_builder_method` calls in `operation_params.mustache` and relocated them to the appropriate `builder.mustache` file.
- Updated `link_builder_method.mustache` to fix logical errors in handling `pathParams` and `queryParams`. Adjustments include:
  - Adding null and empty checks for path and query parameters.
  - Properly formatting the `convertValue` and `resolveUrlQueryParamValuesType` calls to improve readability and maintainability.
- Modified `get_query_params.mustache` to replace the outdated `stringifyExplode` with `explode` for better compatibility with the collection format stringifier.
- Updated `imports.mustache` to include the correct `explode` import from `UrlQueryParamStringifier`.
- Ensured consistent formatting and logical structure across all templates.

# Testing
The changes were validated using the following testing strategies:
- Generated code was inspected for correctness by running the updated templates against various inputs and verifying the output.
- Unit tests were executed to ensure that the modified templates produce the desired behavior.
- Edge cases involving empty or null parameters were specifically tested to confirm robust handling.

# Results
The following improvements have been achieved:
- Fixed bugs related to parameter handling in generated code.
- Enhanced the readability, maintainability, and correctness of the templates.
- Improved compatibility with the `swaggerCollectionFormatStringifier` by using the correct `explode` method.
- Ensured that all required imports are included and correctly referenced.

# Notes
**NaN**