### PR TITLE
fix: improve validation logic in mustache templates

### DIFF
--- a/expediagroup-sdk-openapi-plugin/src/main/resources/templates/data_class.mustache
+++ b/expediagroup-sdk-openapi-plugin/src/main/resources/templates/data_class.mustache
@@ -1,5 +1,6 @@
 {{#processModel}}
     import com.fasterxml.jackson.annotation.JsonProperty
+    import com.expediagroup.sdk.core.common.getOrThrow
     {{#discriminator}}
         import com.fasterxml.jackson.annotation.JsonIgnoreProperties
         import com.fasterxml.jackson.annotation.JsonSubTypes
@@ -22,7 +23,7 @@
         {{/discriminator.mappedModels}}
         )
     {{/discriminator}}
-    {{#nonPublicApi}}internal {{/nonPublicApi}}{{#discriminator}}interface {{/discriminator}}{{^discriminator}}data class {{/discriminator}}{{classname}}{{^discriminator}}(
+    {{#nonPublicApi}}internal {{/nonPublicApi}}{{#discriminator}}interface {{/discriminator}}{{^discriminator}}@ConsistentCopyVisibility data class {{/discriminator}}{{classname}}{{^discriminator}} private constructor(
     {{#allVars}}
         {{#eliminateDiscriminators}}
             {{#required}}{{>data_class_req_var}}{{/required}}{{^required}}{{>data_class_opt_var}}{{/required}}{{^-last}},{{/-last}}
@@ -42,47 +43,46 @@
     {{/discriminator}}
 
     {{^discriminator}}
-        init {
-        {{>partials/data_class_validations}}
-        }
-
         companion object {
-        @JvmStatic
-        fun builder() = Builder()
+            @JvmStatic
+            fun builder() = Builder()
         }
 
         class Builder(
-        {{#allVars}}
-            {{#eliminateDiscriminators}}
-                private var {{{name}}}: {{#isEnum}}{{#isArray}}kotlin.collections.List<{{classname}}.{{{nameInPascalCase}}}>{{/isArray}}{{^isArray}}{{#isInherited}}{{{parent}}}.{{{nameInPascalCase}}}{{/isInherited}}{{^isInherited}}{{classname}}.{{{nameInPascalCase}}}{{/isInherited}}{{/isArray}}{{/isEnum}}{{^isEnum}}{{{dataType}}}{{/isEnum}}? = null{{^-last}},{{/-last}}
-            {{/eliminateDiscriminators}}
-        {{/allVars}}
+            {{#allVars}}
+                {{#eliminateDiscriminators}}
+                    private var {{{name}}}: {{#isEnum}}{{#isArray}}kotlin.collections.List<{{classname}}.{{{nameInPascalCase}}}>{{/isArray}}{{^isArray}}{{#isInherited}}{{{parent}}}.{{{nameInPascalCase}}}{{/isInherited}}{{^isInherited}}{{classname}}.{{{nameInPascalCase}}}{{/isInherited}}{{/isArray}}{{/isEnum}}{{^isEnum}}{{{dataType}}}{{/isEnum}}? = null{{^-last}},{{/-last}}
+                {{/eliminateDiscriminators}}
+            {{/allVars}}
         ) {
-        {{#allVars}}
-            {{#eliminateDiscriminators}}
-                fun {{{name}}}({{{name}}}: {{#isEnum}}{{#isArray}}kotlin.collections.List<{{classname}}.{{{nameInPascalCase}}}>{{/isArray}}{{^isArray}}{{#isInherited}}{{{parent}}}.{{{nameInPascalCase}}}{{/isInherited}}{{^isInherited}}{{classname}}.{{{nameInPascalCase}}}{{/isInherited}}{{/isArray}}{{/isEnum}}{{^isEnum}}{{{dataType}}}{{/isEnum}}{{^required}}?{{/required}}) = apply { this.{{{name}}} = {{{name}}} }
-            {{/eliminateDiscriminators}}
-        {{/allVars}}
+            {{#allVars}}
+                {{#eliminateDiscriminators}}
+                    fun {{{name}}}({{{name}}}: {{#isEnum}}{{#isArray}}kotlin.collections.List<{{classname}}.{{{nameInPascalCase}}}>{{/isArray}}{{^isArray}}{{#isInherited}}{{{parent}}}.{{{nameInPascalCase}}}{{/isInherited}}{{^isInherited}}{{classname}}.{{{nameInPascalCase}}}{{/isInherited}}{{/isArray}}{{/isEnum}}{{^isEnum}}{{{dataType}}}{{/isEnum}}{{^required}}?{{/required}}) = apply { this.{{{name}}} = {{{name}}} }
+                {{/eliminateDiscriminators}}
+            {{/allVars}}
 
-        fun build(): {{classname}} {
-        val instance = {{classname}}(
-        {{#allVars}}
-            {{#eliminateDiscriminators}}
-                {{{name}}} = {{{name}}}{{#required}}!!{{/required}}{{^-last}},{{/-last}}
-            {{/eliminateDiscriminators}}
-        {{/allVars}}
-        )
+            fun build(): {{classname}} {
 
-        return instance
-        }
+                {{>partials/data_class_validations}}
+
+                val instance = {{classname}}(
+                    {{#allVars}}
+                        {{#eliminateDiscriminators}}
+                            {{{name}}} = {{{name}}}{{^-last}},{{/-last}}
+                        {{/eliminateDiscriminators}}
+                    {{/allVars}}
+                )
+
+                return instance
+            }
         }
 
         fun toBuilder() = Builder(
-        {{#allVars}}
-            {{#eliminateDiscriminators}}
-                {{{name}}} = {{{name}}}{{#required}}!!{{/required}}{{^-last}},{{/-last}}
-            {{/eliminateDiscriminators}}
-        {{/allVars}}
+            {{#allVars}}
+                {{#eliminateDiscriminators}}
+                    {{{name}}} = {{{name}}}{{^-last}},{{/-last}}
+                {{/eliminateDiscriminators}}
+            {{/allVars}}
         )
     {{/discriminator}}
     {{#hasEnums}}

--- a/expediagroup-sdk-openapi-plugin/src/main/resources/templates/operation_params.mustache
+++ b/expediagroup-sdk-openapi-plugin/src/main/resources/templates/operation_params.mustache
@@ -18,17 +18,14 @@ package {{ operationPackage }}
                 {{/nonBodyParams}}
                 */
                 @JsonDeserialize(builder = {{classname}}Params.Builder::class)
-                data class {{classname}}Params(
+                @ConsistentCopyVisibility
+                data class {{classname}}Params private constructor(
                 {{#nonBodyParams}}
                     {{#params}}
                         {{>modelMutable}} {{>client/apiParam}}{{^-last}}, {{/-last}}
                     {{/params}}
                 {{/nonBodyParams}}
                 ) {
-
-                init {
-                {{>partials/operation_params_validations}}
-                }
 
                 companion object {
                     @JvmStatic

--- a/expediagroup-sdk-openapi-plugin/src/main/resources/templates/operations/params/builder.mustache
+++ b/expediagroup-sdk-openapi-plugin/src/main/resources/templates/operations/params/builder.mustache
@@ -16,14 +16,14 @@ class Builder(
 {{/nonBodyParams}}
 
     fun build(): {{classname}}Params {
+        {{>partials/operation_params_validations}}
         val params = {{classname}}Params(
         {{#nonBodyParams}}
             {{#params}}
-                {{{paramName}}} = {{{paramName}}}{{#required}}!!{{/required}}{{^-last}},{{/-last}}
+                {{{paramName}}} = {{{paramName}}}{{^-last}},{{/-last}}
             {{/params}}
         {{/nonBodyParams}}
         )
-
         return params
     }
 

--- a/expediagroup-sdk-openapi-plugin/src/main/resources/templates/operations/params/get_headers.mustache
+++ b/expediagroup-sdk-openapi-plugin/src/main/resources/templates/operations/params/get_headers.mustache
@@ -1,9 +1,14 @@
 {{#hasHeaderParams}}fun getHeaders(): Headers {
 return Headers.builder().apply {
 {{#headerParams}}
-    {{paramName}}?.let {
-    add("{{baseName}}", it{{#isEnum}}.value{{/isEnum}})
-    }
+    {{#required}}
+        add("{{baseName}}", {{paramName}}{{#isEnum}}.value{{/isEnum}})
+    {{/required}}
+    {{^required}}
+        {{paramName}}?.let {
+            add("{{baseName}}", it{{#isEnum}}.value{{/isEnum}})
+        }
+    {{/required}}
 {{/headerParams}}
 {{#responses}}
     {{#httpAcceptHeader}}

--- a/expediagroup-sdk-openapi-plugin/src/main/resources/templates/operations/params/get_path_params.mustache
+++ b/expediagroup-sdk-openapi-plugin/src/main/resources/templates/operations/params/get_path_params.mustache
@@ -1,7 +1,7 @@
 {{#hasPathParams}}fun getPathParams() : Map<String, String> {
 return buildMap {
     {{#pathParams}}
-        {{paramName}}?.also {
+        {{paramName}}{{^required}}?{{/required}}.also {
         put("{{{baseName}}}", {{{paramName}}}{{#isEnum}}.value{{/isEnum}})
         }
     {{/pathParams}}

--- a/expediagroup-sdk-openapi-plugin/src/main/resources/templates/operations/params/get_query_params.mustache
+++ b/expediagroup-sdk-openapi-plugin/src/main/resources/templates/operations/params/get_query_params.mustache
@@ -1,23 +1,25 @@
-{{#hasQueryParams}}fun getQueryParams(): List<UrlQueryParam> =
-    buildList {
-{{#queryParams}}
-    {{{paramName}}}?.let {
-        val key = "{{{baseName}}}"
-        val value = buildList {
-    {{#isContainer}}
-            addAll(it{{^isString}}.map { v -> v{{#isEnum}}.value{{/isEnum}}.toString() }{{/isString}})
-    {{/isContainer}}
-    {{^isContainer}}
-            add(it{{#isEnum}}.value{{/isEnum}}{{^isString}}.toString(){{/isString}})
-    {{/isContainer}}
-        }
+{{#hasQueryParams}}
+fun getQueryParams(): List<UrlQueryParam> = buildList {
+    {{#queryParams}}
+        {{{paramName}}}{{^required}}?{{/required}}.let {
+            val key = "{{{baseName}}}"
+            val value = buildList {
+                {{#isContainer}}
+                        addAll(it{{^isString}}.map { v -> v{{#isEnum}}.value{{/isEnum}}.toString() }{{/isString}})
+                {{/isContainer}}
+                {{^isContainer}}
+                        add(it{{#isEnum}}.value{{/isEnum}}{{^isString}}.toString(){{/isString}})
+                {{/isContainer}}
+            }
 
-        add(UrlQueryParam(
-        key = key,
-        value = value,
-        stringify = swaggerCollectionFormatStringifier.getOrDefault("{{collectionFormat}}", explode)
-        ))
+            add(
+                UrlQueryParam(
+                    key = key,
+                    value = value,
+                    stringify = swaggerCollectionFormatStringifier.getOrDefault("{{collectionFormat}}", explode)
+                )
+            )
         }
-{{/queryParams}}
-    }
+    {{/queryParams}}
+}
 {{/hasQueryParams}}

--- a/expediagroup-sdk-openapi-plugin/src/main/resources/templates/operations/params/imports.mustache
+++ b/expediagroup-sdk-openapi-plugin/src/main/resources/templates/operations/params/imports.mustache
@@ -1,3 +1,5 @@
+import com.expediagroup.sdk.core.common.getOrThrow
+
 {{>traits/imports}}
 {{#imports}}
 import {{{import}}}

--- a/expediagroup-sdk-openapi-plugin/src/main/resources/templates/partials/data_class_validations.mustache
+++ b/expediagroup-sdk-openapi-plugin/src/main/resources/templates/partials/data_class_validations.mustache
@@ -1,33 +1,41 @@
 {{#allVars}}
-    {{#minLength}}
-        require({{{name}}}?.length ?: 0 >= {{minLength}}) { "{{{name}}} must be at least {{minLength}} characters long" }
-    {{/minLength}}
+    {{#eliminateDiscriminators}}
+        {{#required}}
+            val {{{name}}} = this.{{{name}}}.getOrThrow {
+                IllegalArgumentException("{{{name}}} must not be null")
+            }
+        {{/required}}
 
-    {{#maxLength}}
-        require({{{name}}}?.length ?: 0 <= {{maxLength}}) { "{{{name}}} must be at most {{maxLength}} characters long" }
-    {{/maxLength}}
+        {{#minLength}}
+            require({{{name}}}?.length ?: 0 >= {{minLength}}) { "{{{name}}} must be at least {{minLength}} characters long" }
+        {{/minLength}}
 
-    {{#pattern}}
-        require({{{name}}}?.matches(Regex("{{{pattern}}}")) ?: true) { "{{{name}}} does not match pattern {{{pattern}}}" }
-    {{/pattern}}
+        {{#maxLength}}
+            require({{{name}}}?.length ?: 0 <= {{maxLength}}) { "{{{name}}} must be at most {{maxLength}} characters long" }
+        {{/maxLength}}
 
-    {{#minItems}}
-        require({{{name}}}?.size ?: 0 >= {{minItems}}) { "{{{name}}} must have at least {{minItems}} items" }
-    {{/minItems}}
+        {{#pattern}}
+            require({{{name}}}?.matches(Regex("{{{pattern}}}")) ?: true) { "{{{name}}} does not match pattern {{{pattern}}}" }
+        {{/pattern}}
 
-    {{#maxItems}}
-        require({{{name}}}?.size ?: 0 <= {{maxItems}}) { "{{{name}}} must have at most {{maxItems}} items" }
-    {{/maxItems}}
+        {{#minItems}}
+            require({{{name}}}?.size ?: 0 >= {{minItems}}) { "{{{name}}} must have at least {{minItems}} items" }
+        {{/minItems}}
 
-    {{#minimum}}
-        require({{{name}}}?.let { it {{#exclusiveMinimum}}> {{/exclusiveMinimum}}{{^exclusiveMinimum}}>= {{/exclusiveMinimum}}{{minimum}} } ?: true) {
-        "{{{name}}} must be {{#exclusiveMinimum}}greater than{{/exclusiveMinimum}}{{^exclusiveMinimum}}at least{{/exclusiveMinimum}} {{minimum}}"
-        }
-    {{/minimum}}
+        {{#maxItems}}
+            require({{{name}}}?.size ?: 0 <= {{maxItems}}) { "{{{name}}} must have at most {{maxItems}} items" }
+        {{/maxItems}}
 
-    {{#maximum}}
-        require({{{name}}}?.let { it {{#exclusiveMaximum}}< {{/exclusiveMaximum}}{{^exclusiveMaximum}}<= {{/exclusiveMaximum}}{{maximum}} } ?: true) {
-        "{{{name}}} must be {{#exclusiveMaximum}}less than{{/exclusiveMaximum}}{{^exclusiveMaximum}}at most{{/exclusiveMaximum}} {{maximum}}"
-        }
-    {{/maximum}}
+        {{#minimum}}
+            require({{{name}}}?.let { it {{#exclusiveMinimum}}> {{/exclusiveMinimum}}{{^exclusiveMinimum}}>= {{/exclusiveMinimum}}{{minimum}} } ?: true) {
+            "{{{name}}} must be {{#exclusiveMinimum}}greater than{{/exclusiveMinimum}}{{^exclusiveMinimum}}at least{{/exclusiveMinimum}} {{minimum}}"
+            }
+        {{/minimum}}
+
+        {{#maximum}}
+            require({{{name}}}?.let { it {{#exclusiveMaximum}}< {{/exclusiveMaximum}}{{^exclusiveMaximum}}<= {{/exclusiveMaximum}}{{maximum}} } ?: true) {
+            "{{{name}}} must be {{#exclusiveMaximum}}less than{{/exclusiveMaximum}}{{^exclusiveMaximum}}at most{{/exclusiveMaximum}} {{maximum}}"
+            }
+        {{/maximum}}
+    {{/eliminateDiscriminators}}
 {{/allVars}}

--- a/expediagroup-sdk-openapi-plugin/src/main/resources/templates/partials/operation_params_validations.mustache
+++ b/expediagroup-sdk-openapi-plugin/src/main/resources/templates/partials/operation_params_validations.mustache
@@ -1,5 +1,11 @@
 {{#nonBodyParams}}
     {{#params}}
+        {{#required}}
+            val {{{paramName}}} = this.{{{paramName}}}.getOrThrow {
+                IllegalArgumentException("{{{paramName}}} must not be null")
+            }
+        {{/required}}
+
         {{#minLength}}
             require({{{paramName}}}?.length ?: 0 >= {{minLength}}) { "{{{paramName}}} must be at least {{minLength}} characters long" }
         {{/minLength}}


### PR DESCRIPTION
# Situation
<!-- Describe the background or context leading to this change. Include why this work is needed (e.g., a specific problem, user need, or opportunity). What is the current state or issue that prompted this PR? -->

1. The generated operations and models contains many warnings about using non-null assertions `!!` and redundant null-safety operator `?`. 

2. The params validation were in `init` blocks which works fine but a better place would be in the build method and validate the builder params directly instead.

# Action
<!-- Summarize the key steps or decisions taken to accomplish the task. Include what changes were made in the codebase, architecture, or process. What actions were implemented to address the task? -->
1. Updated the templates to reduce the `!!` and `?` usage.
2. Updated the templates to use the params validation logic in the build method
3. Made the params and models constructors private to enforce using the builder method.