### PR TITLE
fix: fix plugin publication name

### DIFF
--- a/expediagroup-sdk-openapi-plugin/build.gradle
+++ b/expediagroup-sdk-openapi-plugin/build.gradle
@@ -56,7 +56,7 @@ tasks {
     publishing {
         afterEvaluate {
             publications {
-                egSdkOpenApiGeneratorPluginMarkerMaven(MavenPublication) {
+                egSdkGeneratorPluginMarkerMaven(MavenPublication) {
                     pom {
                         description = findProperty("DESCRIPTION")
                         url = project.property("POM_URL")


### PR DESCRIPTION
# Situation
Renamed `egSdkOpenApiGeneratorPluginMarkerMaven` to the new name `egSdkGeneratorPluginMarkerMaven` in the publishing task