### PR TITLE
fix: read loggable body based on the buffer size

### DIFF
--- a/expediagroup-sdk-core/src/main/kotlin/com/expediagroup/sdk/core/logging/Constant.kt
+++ b/expediagroup-sdk-core/src/main/kotlin/com/expediagroup/sdk/core/logging/Constant.kt
@@ -20,6 +20,6 @@ internal object Constant {
     const val NEWLINE = "\n"
     const val OMITTED = "<-- omitted -->"
     const val DEFAULT_LOG_MASKING_REPLACEMENT_TEMPLATE = "\"$1$2${OMITTED}\""
-    const val DEFAULT_MAX_BODY_SIZE = 8192L // 8KB
+    const val DEFAULT_MAX_BODY_SIZE = 1000000L // 1MB
     const val EXPEDIA_GROUP_SDK = "Expedia Group SDK"
 }

--- a/expediagroup-sdk-core/src/main/kotlin/com/expediagroup/sdk/core/logging/RequestLogger.kt
+++ b/expediagroup-sdk-core/src/main/kotlin/com/expediagroup/sdk/core/logging/RequestLogger.kt
@@ -20,7 +20,6 @@ import com.expediagroup.sdk.core.http.Headers
 import com.expediagroup.sdk.core.http.MediaType
 import com.expediagroup.sdk.core.http.Request
 import com.expediagroup.sdk.core.http.RequestBody
-import com.expediagroup.sdk.core.logging.Constant.DEFAULT_MAX_BODY_SIZE
 import okio.Buffer
 import java.io.IOException
 import java.nio.charset.Charset
@@ -30,7 +29,6 @@ internal object RequestLogger {
         logger: LoggerDecorator,
         request: Request,
         vararg tags: String,
-        maxBodyLogSize: Long? = null,
         maskBody: (String) -> String = { it },
         maskHeaders: (Headers) -> Headers = { it },
         loggableContentTypes: List<MediaType>? = null
@@ -46,7 +44,6 @@ internal object RequestLogger {
                     request.body?.let {
                         maskBody(
                             it.readLoggableBody(
-                                maxBodyLogSize = maxBodyLogSize,
                                 charset = it.mediaType()?.charset,
                                 loggableContentTypes = loggableContentTypes
                             )
@@ -65,7 +62,6 @@ internal object RequestLogger {
 
     @Throws(IOException::class)
     private fun RequestBody.readLoggableBody(
-        maxBodyLogSize: Long?,
         charset: Charset?,
         loggableContentTypes: List<MediaType>?
     ): String {
@@ -80,8 +76,7 @@ internal object RequestLogger {
         }
 
         val buffer = Buffer().apply { use { writeTo(this) } }
-        val bytesToRead = minOf(maxBodyLogSize ?: DEFAULT_MAX_BODY_SIZE, buffer.size)
 
-        return buffer.readString(bytesToRead, charset ?: Charsets.UTF_8)
+        return buffer.readString(buffer.size, charset ?: Charsets.UTF_8)
     }
 }

--- a/expediagroup-sdk-core/src/main/kotlin/com/expediagroup/sdk/core/pipeline/step/RequestLoggingStep.kt
+++ b/expediagroup-sdk-core/src/main/kotlin/com/expediagroup/sdk/core/pipeline/step/RequestLoggingStep.kt
@@ -27,7 +27,6 @@ import okio.Buffer
 
 class RequestLoggingStep(
     private val logger: LoggerDecorator,
-    private val maxRequestBodySize: Long? = null,
     private val maskBody: (String) -> String = { it },
     private val maskHeaders: (Headers) -> Headers = { it },
     private val loggableContentTypes: List<MediaType> = emptyList()
@@ -46,7 +45,6 @@ class RequestLoggingStep(
         RequestLogger.log(
             logger,
             reusableRequest,
-            maxBodyLogSize = maxRequestBodySize,
             maskBody = maskBody,
             maskHeaders = maskHeaders,
             loggableContentTypes = loggableContentTypes

--- a/expediagroup-sdk-core/src/test/kotlin/com/expediagroup/sdk/core/logging/RequestLoggerTest.kt
+++ b/expediagroup-sdk-core/src/test/kotlin/com/expediagroup/sdk/core/logging/RequestLoggerTest.kt
@@ -226,34 +226,6 @@ class RequestLoggerTest {
     }
 
     @Test
-    fun `should respect max log size for request body`() {
-        // Given
-        val bodyContent = """{"key":"value"}"""
-        val buffer = Buffer().write(bodyContent.toByteArray())
-
-        val testRequest =
-            Request
-                .builder()
-                .url("https://example.com")
-                .method(Method.GET)
-                .body(RequestBody.create(buffer, mediaType = CommonMediaTypes.APPLICATION_JSON))
-                .build()
-
-        every { mockLogger.isDebugEnabled } returns true
-
-        // When
-        RequestLogger.log(mockLogger, testRequest, maxBodyLogSize = 1L)
-
-        // Expect
-        val expectedLogMessage =
-            """
-            URL=https://example.com, Method=GET, Headers=[{}], Body={
-            """.trimIndent()
-
-        verify { mockLogger.debug(expectedLogMessage, "Outgoing", *anyVararg<String>()) }
-    }
-
-    @Test
     fun `should call masker with each log on debug level`() {
         val json = """{"username":"john", "apiKey":"secret123", "email":"john@example.com", "password":"p@ssw0rd"}"""
         val bodyContent = Buffer().write(json.toByteArray())

--- a/expediagroup-sdk-core/src/test/kotlin/com/expediagroup/sdk/core/pipeline/step/RequestLoggingStepTest.kt
+++ b/expediagroup-sdk-core/src/test/kotlin/com/expediagroup/sdk/core/pipeline/step/RequestLoggingStepTest.kt
@@ -22,7 +22,7 @@ class RequestLoggingStepTest {
     @BeforeEach
     fun setUp() {
         mockLogger = mockk(relaxed = true)
-        loggingStep = RequestLoggingStep(logger = mockLogger, maxRequestBodySize = 1024L)
+        loggingStep = RequestLoggingStep(logger = mockLogger)
     }
 
     @Test


### PR DESCRIPTION
# Situation
<!-- Describe the background or context leading to this change. Include why this work is needed (e.g., a specific problem, user need, or opportunity). What is the current state or issue that prompted this PR? -->
The current response body logger depends on the content-length to log the body; if the content-length is unknown, it skips reading the buffer. However, there are some cases where the content body is loggable but we still get the content-length=-1 (e.g. the response is gzip). The body is loggable after decompression but the logger ignores it because of the unknown content length.

# Task
<!-- Explain the goal or objective of this change. What specifically needs to be achieved to resolve the situation? Clearly define the scope of the task at hand. -->
Fix the response logger implementation to depend on the actual buffer size instead of the content-length property - after ensuring that the response body is actually loggable.

# Action
<!-- Summarize the key steps or decisions taken to accomplish the task. Include what changes were made in the codebase, architecture, or process. What actions were implemented to address the task? -->
1. Removed the `content-length` check from the response logger.
2. Increased the default max loggable body size
3. Removed the `maxLoggableBodySize` for the request body; as we already reading the whole buffer.

# Testing
<!-- Describe the testing strategy or approach used to validate the changes. Include any relevant test cases, scenarios, or data used to verify the work. How was the work tested? -->
Added necessary tests and verified locally. 

# Results
<!-- Detail the outcomes of the actions. What improvements or changes have been achieved? Include performance gains, bug fixes, or other tangible outcomes. How will you measure or verify success? -->
Responses with unknown content-length is still loggable as long as it has loggable media type.
