### PR TITLE
fix: patch minor mustache templates bugs 

### DIFF
--- a/expediagroup-sdk-openapi-plugin/src/main/kotlin/com/expediagroup/sdk/openapigenerator/EgSdkGeneratorPlugin.kt
+++ b/expediagroup-sdk-openapi-plugin/src/main/kotlin/com/expediagroup/sdk/openapigenerator/EgSdkGeneratorPlugin.kt
@@ -46,7 +46,7 @@ import org.gradle.api.Project
  * plugins { id("com.expediagroup.sdk.openapigenerator") }
  *
  * egSdkGenerator {
- *     namespace.set("cars")
+ *     basePackage.set("com.expediagroup.sdk.example")
  *     specFilePath.set(layout.projectDirectory.file("specs/cars.yaml"))
  *     customTemplatesDir.set(layout.projectDirectory.dir("my-templates"))
  * }
@@ -72,7 +72,6 @@ class EgSdkGeneratorPlugin : Plugin<Project> {
                     it.dependsOn(mergeCustomTemplatesTask)
 
                     it.specFilePath.set(egSdkGeneratorExt.specFilePath)
-                    it.namespace.set(egSdkGeneratorExt.namespace)
                     it.objectMapper.set(egSdkGeneratorExt.objectMapper)
                     it.customTemplatesDir.set(mergeCustomTemplatesTask.flatMap { mergeTask -> mergeTask.mergedDir })
                     it.basePackage.set(egSdkGeneratorExt.basePackage)

--- a/expediagroup-sdk-openapi-plugin/src/main/kotlin/com/expediagroup/sdk/openapigenerator/extension/EgSdkGeneratorExtension.kt
+++ b/expediagroup-sdk-openapi-plugin/src/main/kotlin/com/expediagroup/sdk/openapigenerator/extension/EgSdkGeneratorExtension.kt
@@ -38,8 +38,8 @@ import org.openapitools.codegen.CodegenOperation
  *
  * ```kotlin
  * egSdkGenerator {
+ *     basePackage = "com.expediagroup.sdk.example"
  *     specFilePath = layout.projectDirectory.file("specs/openapi.yaml")
- *     namespace = "rapid"
  * }
  * ```
  */
@@ -65,9 +65,6 @@ abstract class EgSdkGeneratorExtension(project: Project) : ExtensionAware {
     /** Final destination directory for the generated Kotlin sources. */
     abstract val outputDir: DirectoryProperty
 
-    /** namespace (e.g. `"rapid"`) inserted into package names {basePackage}.{namespace} */
-    abstract val namespace: Property<String>
-
     /** User-supplied processors that post-process **operations** before templating. */
     abstract val operationProcessors: ListProperty<(CodegenOperation) -> CodegenOperation>
 
@@ -85,8 +82,8 @@ abstract class EgSdkGeneratorExtension(project: Project) : ExtensionAware {
 
     init {
         // Default values
-        modelPackage.set(namespace.map { ns -> "com.expediagroup.sdk.$ns.model" })
-        operationPackage.set(namespace.map { ns -> "com.expediagroup.sdk.$ns.operation" })
+        modelPackage.set(basePackage.map { bp -> "$bp.model" })
+        operationPackage.set(basePackage.map { bp -> "$bp.operation" })
         outputDir.set(project.layout.projectDirectory.dir("src/main/kotlin"))
     }
 }

--- a/expediagroup-sdk-openapi-plugin/src/main/kotlin/com/expediagroup/sdk/openapigenerator/task/GenerateEgSdkTask.kt
+++ b/expediagroup-sdk-openapi-plugin/src/main/kotlin/com/expediagroup/sdk/openapigenerator/task/GenerateEgSdkTask.kt
@@ -57,9 +57,6 @@ import kotlin.collections.joinToString
  * It allows customization of the generated code through various properties and templates.
  */
 abstract class GenerateEgSdkTask : DefaultTask() {
-    @get:Input
-    abstract val namespace: Property<String>
-
     @get:InputFile
     abstract val specFilePath: RegularFileProperty
 
@@ -107,10 +104,11 @@ abstract class GenerateEgSdkTask : DefaultTask() {
 
     @TaskAction
     fun generate() {
-        val supportingFilesNames = supportingTemplates.orNull
-            ?.joinToString(",") { it.fileName }
-            .orEmpty()
-            .ifEmpty { "false" }
+        val supportingFilesNames =
+            supportingTemplates.orNull
+                ?.joinToString(",") { it.fileName }
+                .orEmpty()
+                .ifEmpty { "false" }
 
         val config =
             CodegenConfigurator().apply {
@@ -136,7 +134,6 @@ abstract class GenerateEgSdkTask : DefaultTask() {
                 addGlobalProperty(CodegenConstants.SUPPORTING_FILES, supportingFilesNames)
 
                 // Additional Properties
-                addAdditionalProperty("namespace", namespace.get())
                 addAdditionalProperty("jacksonObjectMapper", objectMapper.get())
                 addAdditionalProperty("modelPackage", modelPackage.get())
                 addAdditionalProperty("operationPackage", operationPackage.get())

--- a/expediagroup-sdk-openapi-plugin/src/main/kotlin/com/expediagroup/sdk/openapigenerator/task/GenerateEgSdkTask.kt
+++ b/expediagroup-sdk-openapi-plugin/src/main/kotlin/com/expediagroup/sdk/openapigenerator/task/GenerateEgSdkTask.kt
@@ -107,7 +107,10 @@ abstract class GenerateEgSdkTask : DefaultTask() {
 
     @TaskAction
     fun generate() {
-        val supportingFilesNames = supportingTemplates.get().joinToString(",") { it.fileName }
+        val supportingFilesNames = supportingTemplates.orNull
+            ?.joinToString(",") { it.fileName }
+            .orEmpty()
+            .ifEmpty { "false" }
 
         val config =
             CodegenConfigurator().apply {
@@ -171,7 +174,7 @@ abstract class GenerateEgSdkTask : DefaultTask() {
                                 template.fileNameSuffix
                             ).also { t -> t.templateType = TemplateFileType.API }
                         }
-                    } ?: emptyList()
+                    }
 
                 val resolvedSupportingTemplates =
                     supportingTemplates.orNull?.let {
@@ -182,12 +185,12 @@ abstract class GenerateEgSdkTask : DefaultTask() {
                                 template.fileName
                             )
                         }
-                    } ?: emptyList()
+                    }
 
                 userDefinedTemplates(
                     buildList {
-                        addAll(resolvedApiTemplates)
-                        addAll(resolvedSupportingTemplates)
+                        resolvedApiTemplates?.let { addAll(it) }
+                        resolvedSupportingTemplates?.let { addAll(it) }
                         add(
                             TemplateDefinition(
                                 "operation_params.mustache",

--- a/expediagroup-sdk-openapi-plugin/src/main/resources/templates/operations/params/get_path_params.mustache
+++ b/expediagroup-sdk-openapi-plugin/src/main/resources/templates/operations/params/get_path_params.mustache
@@ -2,7 +2,7 @@
 return buildMap {
     {{#pathParams}}
         {{paramName}}{{^required}}?{{/required}}.also {
-        put("{{{baseName}}}", {{{paramName}}}{{#isEnum}}.value{{/isEnum}})
+        put("{{{baseName}}}", {{{paramName}}}{{#isEnum}}.value{{/isEnum}}{{^isString}}.toString(){{/isString}})
         }
     {{/pathParams}}
     }

--- a/expediagroup-sdk-openapi-plugin/src/main/resources/templates/traits/implementation.mustache
+++ b/expediagroup-sdk-openapi-plugin/src/main/resources/templates/traits/implementation.mustache
@@ -11,7 +11,7 @@ override fun getUrlPath(): String {
         {{#pathParams}}
             url = url.replace(
                 oldValue = "{" + "{{{baseName}}}" + "}",
-                newValue = this.params.{{{paramName}}}{{#isEnum}}.value{{/isEnum}},
+            newValue = this.params.{{{paramName}}}{{#isEnum}}.value{{/isEnum}}{{^isString}}.toString(){{/isString}},
                 ignoreCase = true
             )
         {{/pathParams}}


### PR DESCRIPTION
# Situation
1. Added missing `toString()` calls when the path variable is not a String.
2. Refactored the `supportingFilesNames` to have the value `false` if the the `supportingTemplates` is null. 